### PR TITLE
chore: break up main.rs into smaller files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "boltzmann"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "lazy_static",
+ "ron",
+ "serde",
+ "serde_json",
+ "structopt",
+ "subprocess",
+ "tera",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,20 +300,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "ludwig"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "lazy_static",
- "ron",
- "serde",
- "serde_json",
- "structopt",
- "subprocess",
- "tera",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["C J Silverio <ceejceej@gmail.com>", "Chris Dickinson <chris@neversaw.us>"]
 edition = "2018"
-name = "ludwig"
+name = "boltzmann"
 version = "0.1.0"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use std::os::unix::fs::{ DirBuilderExt, OpenOptionsExt };
 use std::collections::HashMap;
 use std::io::prelude::*;
 use std::path::PathBuf;
@@ -7,72 +6,15 @@ use anyhow::{ anyhow, Context as ErrorContext, Result };
 use subprocess::{ Exec, ExitStatus, NullFile };
 use serde::{ Serialize, Deserialize };
 use serde_json::{ Value, self };
-use tera::{ Tera, Context };
 use structopt::StructOpt;
 
-lazy_static::lazy_static! {
-    pub static ref TEMPLATES: Tera = {
-        match Tera::new("templates/**/*") {
-            Ok(t) => t,
-            Err(e) => {
-                println!("Parsing error(s): {}", e);
-                ::std::process::exit(1);
-            }
-        }
-    };
-}
+mod render;
+mod settings;
 
-#[derive(Clone, Serialize, Deserialize)]
-enum Flipper {
-    Off,
-    On
-}
-
-impl Into<bool> for Flipper {
-    fn into(self) -> bool {
-        match self {
-            Flipper::On => true,
-            Flipper::Off => false
-        }
-    }
-}
-
-impl Into<Flipper> for bool {
-    fn into(self) -> Flipper {
-        if self {
-            Flipper::On
-        } else {
-            Flipper::Off
-        }
-    }
-}
-
-impl std::str::FromStr for Flipper {
-    type Err = Box<dyn std::error::Error + 'static>;
-
-    fn from_str(s: &str) -> Result<Flipper, Self::Err> {
-        Ok(match s {
-            "on" => Flipper::On,
-            "ON" => Flipper::On,
-            "true" => Flipper::On,
-            "yes" => Flipper::On,
-            "y" => Flipper::On,
-            "1" => Flipper::On,
-
-            "0" => Flipper::Off,
-            "n" => Flipper::Off,
-            "no" => Flipper::Off,
-            "false" => Flipper::Off,
-            "OFF" => Flipper::Off,
-            "off" => Flipper::Off,
-
-            _ => return Err(anyhow::anyhow!("This is not a valid feature flag value.").into())
-        })
-    }
-}
+use settings::{ Flipper, Settings, When };
 
 #[derive(Clone, Serialize, StructOpt)]
-struct Flags {
+pub struct Flags {
     #[structopt(long, help = "Apply changes to destination even if there are changes")]
     force: bool, // for enemies
 
@@ -101,82 +43,6 @@ struct Flags {
     destination: PathBuf
 }
 
-#[derive(Serialize, Deserialize, Default, Clone, Debug)]
-struct Settings {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    version: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    redis: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    postgres: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    honeycomb: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    selftest: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    githubci: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    status: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    ping: Option<bool>,
-
-    #[serde(flatten)]
-    pub(crate) rest: HashMap<String, Value>,
-}
-
-impl Settings {
-    fn merge_flags(&self, version: String, flags: &Flags) -> Settings {
-        let cast = |xs: &Option<Option<Flipper>>, default: &Option<bool>| -> Option<bool> {
-            match xs {
-                Some(None) => Some(true),                       // e.g., --postgres
-                Some(Some(Flipper::On)) => Some(true),          // e.g., --postgres=on
-                Some(Some(Flipper::Off)) => Some(false),        // e.g., --postgres=off
-                None => default.map(|xs| xs)
-            }
-        };
-
-        Settings {
-            version: Some(version),
-            redis: cast(&flags.redis, &self.redis),
-            postgres: cast(&flags.postgres, &self.postgres),
-            honeycomb: cast(&flags.honeycomb, &self.honeycomb),
-            githubci: cast(&flags.githubci, &self.githubci),
-            status: cast(&flags.status, &self.status),
-            ping: cast(&flags.ping, &self.ping),
-            selftest: if flags.selftest {
-                Some(true)
-            } else {
-                None
-            },
-            rest: HashMap::new()
-        }
-    }
-}
-
-impl Into<Context> for Settings {
-    fn into(self) -> Context {
-        let mut ctxt = Context::new();
-
-        ctxt.insert("redis", &self.redis.unwrap_or(false));
-        ctxt.insert("postgres", &self.postgres.unwrap_or(false));
-        ctxt.insert("honeycomb", &self.honeycomb.unwrap_or(false));
-        ctxt.insert("selftest", &self.selftest.unwrap_or(false));
-        ctxt.insert("githubci", &self.githubci.unwrap_or(false));
-        ctxt.insert("status", &self.status.unwrap_or(false));
-        ctxt.insert("ping", &self.ping.unwrap_or(false));
-        ctxt.insert("version", &self.version.unwrap_or_else(|| "<unknown version>".to_string())[..]);
-
-        ctxt
-    }
-}
-
 #[derive(Default, Deserialize, Serialize)]
 struct PackageJson {
     dependencies: Option<HashMap<String, String>>,
@@ -188,101 +54,6 @@ struct PackageJson {
 
     #[serde(flatten)]
     pub(crate) rest: HashMap<String, Value>,
-}
-
-#[derive(Deserialize)]
-enum Node {
-    Dir(DirSpec),
-    File(FileSpec),
-    Template(TemplateSpec)
-}
-
-#[derive(Deserialize, Default)]
-struct When {
-    feature: Option<String>,
-    if_not_present: Vec<String>
-}
-
-#[derive(Deserialize)]
-struct DirSpec {
-    children: Vec<(String, u32, Node, Option<When>)>,
-}
-
-#[derive(Deserialize)]
-struct FileSpec {
-    contents: String,
-}
-
-#[derive(Deserialize)]
-struct TemplateSpec {
-    template_name: String
-}
-
-impl Node {
-    pub fn render(self, cwd: &mut PathBuf, mode: u32, parents: &mut Vec<String>, settings: &Settings) -> Result<Option<String>> {
-        match self {
-            Node::Dir(spec) => render_dir(spec, cwd, mode, parents, settings),
-            Node::File(spec) => Ok(Some(spec.contents)),
-            Node::Template(spec) => {
-                let target = parents.join("/");
-                let mut context: Context = settings.clone().into();
-                context.insert("filename", &target[..]);
-                Ok(Some(TEMPLATES.render(&spec.template_name[..], &context)?))
-            },
-        }
-    }
-}
-
-fn render_dir(spec: DirSpec, cwd: &mut PathBuf, mode: u32, parents: &mut Vec<String>, settings: &Settings) -> Result<Option<String>> {
-
-    println!("entering \x1b[34m{:?}\x1b[0m;", cwd);
-    if let Err(e) = std::fs::DirBuilder::new().mode(mode).create(&cwd) {
-        if e.kind() != std::io::ErrorKind::AlreadyExists {
-            return Err(e.into())
-        }
-    }
-
-    'next:
-    for (basename, mode, node, when) in spec.children {
-        if let Some(preconditions) = when {
-            if let Some(feature) = preconditions.feature {
-                let mapped = serde_json::to_value(settings)?;
-                let has_feature = mapped.get(feature)
-                    .map(|xs| xs.as_bool().unwrap_or(false))
-                    .unwrap_or(false);
-
-                if !has_feature {
-                    continue
-                }
-            }
-
-            let mut cloned_cwd = cwd.clone();
-            for dir in preconditions.if_not_present {
-                // if any of these directories exist, bail
-                cloned_cwd.push(dir);
-                if cloned_cwd.as_path().exists() {
-                    continue 'next
-                }
-                cloned_cwd.pop();
-            }
-        }
-
-        cwd.push(&basename[..]);
-        parents.push(basename.clone());
-
-        // failure to render is fatal.
-        if let Some(data) = node.render(cwd, mode, parents, settings)? {
-            let mut fd = std::fs::OpenOptions::new().create(true).truncate(true).write(true).mode(mode).open(&cwd)
-                .with_context(|| format!("failed to open {:?} with mode {:?}", cwd, mode))?;
-
-            fd.write_all(data.as_bytes())
-                .with_context(|| format!("failed to write {:?}", cwd))?;
-        }
-        cwd.pop();
-        parents.pop();
-    }
-
-    Ok(None)
 }
 
 fn load_package_json(flags: &Flags, default_settings: Settings) -> Option<PackageJson> {
@@ -366,9 +137,7 @@ struct DependencySpec {
 }
 
 fn main() -> std::result::Result<(), Box<dyn std::error::Error + 'static>> {
-    let root_node: Node = ron::de::from_str(include_str!("dirspec.ron"))?;
     let flags = Flags::from_args();
-    let mut parents = Vec::new();
     let mut cwd = flags.destination.clone();
 
     check_git_status(&flags)?;
@@ -398,7 +167,9 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error + 'static>> {
 
     let settings = package_json.boltzmann.take().unwrap();
     let updated_settings = settings.merge_flags("the version of boltzmann".to_string(), &flags);
-    root_node.render(&mut cwd, 0o777, &mut parents, &updated_settings)?;
+
+    render::scaffold(&mut cwd, &updated_settings)
+        .with_context(|| format!("could not render boltzmann files!"))?;
 
     let old = serde_json::to_value(settings)?;
     let new = serde_json::to_value(&updated_settings)?;

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,119 @@
+use std::io::prelude::*;
+use std::os::unix::fs::{ DirBuilderExt, OpenOptionsExt };
+use std::path::PathBuf;
+
+use anyhow::{ Context as ErrorContext, Result };
+use serde::{ Deserialize };
+use tera::{ Tera, Context };
+
+use super::Settings;
+use super::When;
+
+lazy_static::lazy_static! {
+    pub static ref TEMPLATES: Tera = {
+        match Tera::new("templates/**/*") {
+            Ok(t) => t,
+            Err(e) => {
+                println!("Parsing error(s): {}", e);
+                ::std::process::exit(1);
+            }
+        }
+    };
+}
+
+#[derive(Deserialize)]
+enum Node {
+    Dir(DirSpec),
+    File(FileSpec),
+    Template(TemplateSpec)
+}
+
+#[derive(Deserialize)]
+struct DirSpec {
+    children: Vec<(String, u32, Node, Option<When>)>,
+}
+
+#[derive(Deserialize)]
+struct FileSpec {
+    contents: String,
+}
+
+#[derive(Deserialize)]
+struct TemplateSpec {
+    template_name: String
+}
+
+impl Node {
+    pub fn render(self, cwd: &mut PathBuf, mode: u32, parents: &mut Vec<String>, settings: &Settings) -> Result<Option<String>> {
+        match self {
+            Node::Dir(spec) => render_dir(spec, cwd, mode, parents, settings),
+            Node::File(spec) => Ok(Some(spec.contents)),
+            Node::Template(spec) => {
+                let target = parents.join("/");
+                let mut context: Context = settings.clone().into();
+                context.insert("filename", &target[..]);
+                Ok(Some(TEMPLATES.render(&spec.template_name[..], &context)?))
+            },
+        }
+    }
+}
+
+fn render_dir(spec: DirSpec, cwd: &mut PathBuf, mode: u32, parents: &mut Vec<String>, settings: &Settings) -> Result<Option<String>> {
+
+    println!("entering \x1b[34m{:?}\x1b[0m;", cwd);
+    if let Err(e) = std::fs::DirBuilder::new().mode(mode).create(&cwd) {
+        if e.kind() != std::io::ErrorKind::AlreadyExists {
+            return Err(e.into())
+        }
+    }
+
+    'next:
+    for (basename, mode, node, when) in spec.children {
+        if let Some(preconditions) = when {
+            if let Some(feature) = preconditions.feature {
+                let mapped = serde_json::to_value(settings)?;
+                let has_feature = mapped.get(feature)
+                    .map(|xs| xs.as_bool().unwrap_or(false))
+                    .unwrap_or(false);
+
+                if !has_feature {
+                    continue
+                }
+            }
+
+            let mut cloned_cwd = cwd.clone();
+            for dir in preconditions.if_not_present {
+                // if any of these directories exist, bail
+                cloned_cwd.push(dir);
+                if cloned_cwd.as_path().exists() {
+                    continue 'next
+                }
+                cloned_cwd.pop();
+            }
+        }
+
+        cwd.push(&basename[..]);
+        parents.push(basename.clone());
+
+        // failure to render is fatal.
+        if let Some(data) = node.render(cwd, mode, parents, settings)? {
+            let mut fd = std::fs::OpenOptions::new().create(true).truncate(true).write(true).mode(mode).open(&cwd)
+                .with_context(|| format!("failed to open {:?} with mode {:?}", cwd, mode))?;
+
+            fd.write_all(data.as_bytes())
+                .with_context(|| format!("failed to write {:?}", cwd))?;
+        }
+        cwd.pop();
+        parents.pop();
+    }
+
+    Ok(None)
+}
+
+pub fn scaffold(mut cwd: &mut PathBuf, settings: &Settings) -> Result<Option<String>> {
+    let root_node: Node = ron::de::from_str(include_str!("dirspec.ron"))?;
+    let mut parents = Vec::new();
+    root_node.render(&mut cwd, 0o777, &mut parents, &settings)?;
+
+    Ok(None)
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,138 @@
+use std::collections::HashMap;
+
+use serde::{ Serialize, Deserialize };
+use serde_json::{ Value, self };
+use tera::Context;
+
+use super::Flags;
+
+#[derive(Deserialize, Default)]
+pub struct When {
+    pub(crate) feature: Option<String>,
+    pub(crate) if_not_present: Vec<String>
+}
+
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
+pub struct Settings {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) version: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) redis: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) postgres: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) honeycomb: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) selftest: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) githubci: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) status: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) ping: Option<bool>,
+
+    #[serde(flatten)]
+    pub(crate) rest: HashMap<String, Value>,
+}
+
+impl Settings {
+    pub fn merge_flags(&self, version: String, flags: &Flags) -> Settings {
+        let cast = |xs: &Option<Option<Flipper>>, default: &Option<bool>| -> Option<bool> {
+            match xs {
+                Some(None) => Some(true),                       // e.g., --postgres
+                Some(Some(Flipper::On)) => Some(true),          // e.g., --postgres=on
+                Some(Some(Flipper::Off)) => Some(false),        // e.g., --postgres=off
+                None => default.map(|xs| xs)
+            }
+        };
+
+        Settings {
+            version: Some(version),
+            redis: cast(&flags.redis, &self.redis),
+            postgres: cast(&flags.postgres, &self.postgres),
+            honeycomb: cast(&flags.honeycomb, &self.honeycomb),
+            githubci: cast(&flags.githubci, &self.githubci),
+            status: cast(&flags.status, &self.status),
+            ping: cast(&flags.ping, &self.ping),
+            selftest: if flags.selftest {
+                Some(true)
+            } else {
+                None
+            },
+            rest: HashMap::new()
+        }
+    }
+}
+
+impl Into<Context> for Settings {
+    fn into(self) -> Context {
+        let mut ctxt = Context::new();
+
+        ctxt.insert("redis", &self.redis.unwrap_or(false));
+        ctxt.insert("postgres", &self.postgres.unwrap_or(false));
+        ctxt.insert("honeycomb", &self.honeycomb.unwrap_or(false));
+        ctxt.insert("selftest", &self.selftest.unwrap_or(false));
+        ctxt.insert("githubci", &self.githubci.unwrap_or(false));
+        ctxt.insert("status", &self.status.unwrap_or(false));
+        ctxt.insert("ping", &self.ping.unwrap_or(false));
+        ctxt.insert("version", &self.version.unwrap_or_else(|| "<unknown version>".to_string())[..]);
+
+        ctxt
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub enum Flipper {
+    Off,
+    On
+}
+
+impl Into<bool> for Flipper {
+    fn into(self) -> bool {
+        match self {
+            Flipper::On => true,
+            Flipper::Off => false
+        }
+    }
+}
+
+impl Into<Flipper> for bool {
+    fn into(self) -> Flipper {
+        if self {
+            Flipper::On
+        } else {
+            Flipper::Off
+        }
+    }
+}
+
+impl std::str::FromStr for Flipper {
+    type Err = Box<dyn std::error::Error + 'static>;
+
+    fn from_str(s: &str) -> Result<Flipper, Self::Err> {
+        Ok(match s {
+            "on" => Flipper::On,
+            "ON" => Flipper::On,
+            "true" => Flipper::On,
+            "yes" => Flipper::On,
+            "y" => Flipper::On,
+            "1" => Flipper::On,
+
+            "0" => Flipper::Off,
+            "n" => Flipper::Off,
+            "no" => Flipper::Off,
+            "false" => Flipper::Off,
+            "OFF" => Flipper::Off,
+            "off" => Flipper::Off,
+
+            _ => return Err(anyhow::anyhow!("This is not a valid feature flag value.").into())
+        })
+    }
+}


### PR DESCRIPTION
I chose to split along these lines:

- the machinery of turning flags into settings is now in src/settings.rs
- node rendering is now in src/render.rs

I didn't move the package.json parsing or git checks, as these seem like major logic that belongs in the main file.

ALSO, renamed the cli from `ludwig` to `boltzmann`.