### PR TITLE
feat: move release workflow to build; add new release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,142 @@
+name: build Boltzmann for release
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: create a github release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Boltzmann ${{ github.ref }}
+          draft: true
+          prerelease: false
+      - run: |
+          echo "${{ steps.create_release.outputs.upload_url }}" > uploadurl.txt
+      - name: save the upload url
+        uses: actions/upload-artifact@v1
+        with:
+          name: jobdata
+          path: uploadurl.txt
+
+  linux:
+    name: linux gnulibc build
+    runs-on: ubuntu-latest
+    needs: [release]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions/download-artifact@v1
+        with:
+          name: jobdata
+      - run: echo ::set-output name=url::$(cat jobdata/uploadurl.txt)
+        id: release_data
+      - run: cargo build --release
+      - run: tar cfz boltzmann_x64_linux.tar.gz -C target/release boltzmann
+      - name: upload x64 linux gnu release
+        id: release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.release_data.outputs.url }}
+          asset_path: ./boltzmann_x64_linux.tar.gz
+          asset_name: boltzmann_x64_linux.tar.gz
+          asset_content_type: application/gzip
+
+  darwin:
+    name: darwin
+    runs-on: macos-latest
+    needs: [release]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions/download-artifact@v1
+        with:
+          name: jobdata
+      - run: echo ::set-output name=url::$(cat jobdata/uploadurl.txt)
+        id: release_data
+      - run: cargo build --release
+      - run: tar cfz boltzmann_x64_darwin.tar.gz -C target/release boltzmann
+      - name: upload darwin release
+        id: release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.release_data.outputs.url }}
+          asset_path: ./boltzmann_x64_darwin.tar.gz
+          asset_name: boltzmann_x64_darwin.tar.gz
+          asset_content_type: application/gzip
+
+  windows:
+    name: windows
+    runs-on: windows-latest
+    needs: [release]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions/download-artifact@v1
+        with:
+          name: jobdata
+      - run: echo "::set-output name=url::$(cat jobdata/uploadurl.txt)"
+        id: release_data
+        shell: bash
+
+      - run: cargo build --release
+      - name: tar it up
+        shell: bash
+        run: |
+          tar cfz boltzmann_x64_windows.tar.gz -C target/release boltzmann
+      - name: upload windows release
+        id: release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.release_data.outputs.url }}
+          asset_path: ./boltzmann_x64_windows.tar.gz
+          asset_name: boltzmann_x64_windows.tar.gz
+          asset_content_type: application/gzip
+
+  docs:
+    name: docs
+    runs-on: ubuntu-latest
+    needs: [release]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v1
+        with:
+          name: jobdata
+      - run: echo ::set-output name=url::$(cat jobdata/uploadurl.txt)
+        id: release_data
+      - run: bin/docs build
+      - name: tar it up
+        shell: bash
+        run: |
+          rm -rf docs/output/.git
+          tar cfz docs.tar.gz -C docs/output .
+      - name: upload docs
+        id: release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.release_data.outputs.url }}
+          asset_path: ./docs.tar.gz
+          asset_name: docs.tar.gz
+          asset_content_type: application/gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,111 +1,60 @@
-name: release Boltzmann
+name: Release Boltzmann
 on:
-  push:
-    tags:
-      - 'v*'
-
+  release:
+    types: [published]
 jobs:
   release:
-    name: release
+    name: publish npm package
     runs-on: ubuntu-latest
     steps:
-      - name: create a github release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Boltzmann ${{ github.ref }}
-          draft: true
-          prerelease: false
-      - run: |
-          echo "${{ steps.create_release.outputs.upload_url }}" > uploadurl.txt
-      - name: save the upload url
-        uses: actions/upload-artifact@v1
-        with:
-          name: jobdata
-          path: uploadurl.txt
-
-  linux:
-    name: linux gnulibc build
-    runs-on: ubuntu-latest
-    needs: [release]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: actions/download-artifact@v1
-        with:
-          name: jobdata
-      - run: echo ::set-output name=url::$(cat jobdata/uploadurl.txt)
-        id: release_data
-      - run: cargo build --release
-      - run: tar cfz boltzmann_x86_linux_gnu.tar.gz -C target/release boltzmann
-      - name: upload x86 linux gnu release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release_data.outputs.url }}
-          asset_path: ./boltzmann_x86_linux_gnu.tar.gz
-          asset_name: boltzmann_x86_linux_gnu.tar.gz
-          asset_content_type: application/gzip
-
-  darwin:
-    name: darwin
-    runs-on: macos-latest
-    needs: [release]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: actions/download-artifact@v1
-        with:
-          name: jobdata
-      - run: echo ::set-output name=url::$(cat jobdata/uploadurl.txt)
-        id: release_data
-      - run: cargo build --release
-      - run: tar cfz boltzmann_x86_darwin.tar.gz -C target/release boltzmann
-      - name: upload darwin release
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release_data.outputs.url }}
-          asset_path: ./boltzmann_x86_darwin.tar.gz
-          asset_name: boltzmann_x86_darwin.tar.gz
-          asset_content_type: application/gzip
-
-  windows:
-    name: windows
-    runs-on: windows-latest
-    needs: [release]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: actions/download-artifact@v1
-        with:
-          name: jobdata
-      - run: echo ::set-output name=url::$(cat jobdata/uploadurl.txt)
-        id: release_data
-      - run: cargo build --release
-      - name: tar it up
-        shell: bash
+          node-version: '12'
+      - name: download release contents
         run: |
-          tar cfz boltzmann_x86_windows.tar.gz -C target/release boltzmann
-      - name: upload windows release
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release_data.outputs.url }}
-          asset_path: ./boltzmann_x86_windows.tar.gz
-          asset_name: boltzmann_x86_windows.tar.gz
-          asset_content_type: application/gzip
+          download_urls = $(
+            curl -sL https://api.github.com/repos/entropic-dev/boltzmann/releases/tags/${{ github.ref }} | \
+              jq -r '.assets[] | .browser_download_url' \
+              grep -v 'docs'
+          )
+
+          mkdir -p boltzmann-cli
+          for url in download_urls; do
+            curl -sL $url | tar zxfv -C boltzmann-cli
+            name=$(basename $url)
+            mv boltzmann-cli/boltzmann boltzmann-cli/boltzmann_${name/tar.gz/}
+          done
+
+      - name: create npm package
+        run: |
+          npm init -y boltzmann-cli
+          jq -rM '.description = "The boltzmann CLI" |' \
+                 '.scripts.test = "echo ok" |' \
+                 '.author = "Static T. Raccoon <static-t-raccoon@example.com> (https://entropic-dev.github.io/boltzmann)" |' \
+                 '.keywords = ["boltzmann", "scaffold http"] |' \
+                 '.license = "Apache-2.0"' \
+                 '.version = "${{ github.ref }}"' < boltzmann-cli/package.json > boltzmann-cli/package.json
+
+          cat > boltzmann-cli/index.js <<-EOF
+            'use strict'
+            const os = require('os')
+            const path = require('path')
+            const fs = require('fs')
+            const spawnSync = require('child_process').spawnSync
+
+            const executable = path.join(__dirname, `boltzmann_\${os.arch()}_\${os.platform()`)
+
+            if (!fs.existsSync(executable)) {
+              console.error("Sorry, boltzmann is not yet supported on %s", os.platform())
+              process.exit(1)
+            }
+
+            spawnSync(executable, process.argv.slice(2))
+          EOF
+
+          cat > .npmrc <<-EOF
+          registry=https://registry.npmjs.org/
+          //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
+          EOF
+          cd boltzmann-cli
+          npm publish

--- a/templates/boltzmann.js
+++ b/templates/boltzmann.js
@@ -41,9 +41,7 @@ const pg = require('pg')
 const THREW = Symbol.for('threw')
 const STATUS = Symbol.for('status')
 const HEADERS = Symbol.for('headers')
-// {% if honeycomb %}
 const TRACE_HTTP_HEADER = 'x-honeycomb-trace'
-// {% endif %}
 
 let ajv = null
 let ajvLoose = null


### PR DESCRIPTION
Make the intended flow:

- git push origin v1.0.0
- Go to GitHub, publish the draft release.
- The GitHub release action (should) build an npm package and
  publish it. In the future, this should also automatically update
  the docs page.