### PR TITLE
Chris/add cookie and templates

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -6,7 +6,7 @@ function run_selftest() {
   rm -rf tmp
   mkdir tmp
 
-  cargo run -- --selftest --jwt --force tmp
+  cargo run -- --selftest --jwt --templates --force tmp
   tmp/node_modules/.bin/tap tmp/test.js
 }
 

--- a/examples/custom-middleware/test/middleware-test.js
+++ b/examples/custom-middleware/test/middleware-test.js
@@ -186,7 +186,7 @@ tap.test('gzip middleware works on objects', _(async assert => {
   const zlib = require('zlib')
 
   assert.equal(res.headers['content-encoding'], 'gzip')
-  assert.equal(res.headers['content-type'], 'application/json')
+  assert.equal(res.headers['content-type'], 'application/json; charset=utf-8')
   assert.equal(String(zlib.gunzipSync(res.rawPayload)), '{"ok":"then"}')
   assert.equal(res.statusCode, 203)
 }))

--- a/src/dependencies.ron
+++ b/src/dependencies.ron
@@ -6,6 +6,24 @@
     preconditions:None
   ),
   DependencySpec(
+    name: "nunjucks",
+    version: "^3.2.1",
+    kind: Normal,
+    preconditions: Some(When(
+      feature: Some("template"),
+      if_not_present: []
+    ))
+  ),
+  DependencySpec(
+    name: "chokidar",
+    version: "^3.4.0",
+    kind: Development,
+    preconditions: Some(When(
+      feature: Some("template"),
+      if_not_present: []
+    ))
+  ),
+  DependencySpec(
     name: "culture-ships",
     version: "^1.0.0",
     kind: Normal,
@@ -76,6 +94,13 @@
     version: "^3.0.2",
     kind: Normal,
     preconditions:Some(When(feature: Some("redis"),if_not_present: []))
+  ),
+
+  DependencySpec(
+    name: "cookie",
+    version: "^0.4.1",
+    kind: Normal,
+    preconditions:None
   ),
 
   DependencySpec(

--- a/src/dependencies.ron
+++ b/src/dependencies.ron
@@ -10,16 +10,7 @@
     version: "^3.2.1",
     kind: Normal,
     preconditions: Some(When(
-      feature: Some("template"),
-      if_not_present: []
-    ))
-  ),
-  DependencySpec(
-    name: "chokidar",
-    version: "^3.4.0",
-    kind: Development,
-    preconditions: Some(When(
-      feature: Some("template"),
+      feature: Some("templates"),
       if_not_present: []
     ))
   ),

--- a/src/dirspec.ron
+++ b/src/dirspec.ron
@@ -10,6 +10,13 @@ Dir(DirSpec(
       if_not_present: ["handlers.js", "handlers"]
     ))),
 
+    ("templates", 0o755, Dir(DirSpec(
+      children: [],
+    )), Some(When(
+      feature: Some("template"),
+      if_not_present: []
+    ))),
+
     (".eslintrc.js", 0o644, Template(TemplateSpec(
       template_name: "eslintrc.js"
     )), Some(When(

--- a/src/dirspec.ron
+++ b/src/dirspec.ron
@@ -13,7 +13,7 @@ Dir(DirSpec(
     ("templates", 0o755, Dir(DirSpec(
       children: [],
     )), Some(When(
-      feature: Some("template"),
+      feature: Some("templates"),
       if_not_present: []
     ))),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,9 @@ pub struct Flags {
     #[structopt(long, help = "Enable GitHub actions CI")]
     githubci: Option<Option<Flipper>>,
 
+    #[structopt(long, help = "Enable Nunjucks templates")]
+    templates: Option<Option<Flipper>>,
+
     #[structopt(long, help = "Enable /monitor/status healthcheck endpoint")]
     status: Option<Option<Flipper>>,
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -36,6 +36,9 @@ pub struct Settings {
     pub(crate) githubci: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) templates: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) status: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -65,6 +68,7 @@ impl Settings {
             postgres: cast(&flags.postgres, &self.postgres),
             honeycomb: cast(&flags.honeycomb, &self.honeycomb),
             githubci: cast(&flags.githubci, &self.githubci),
+            templates: cast(&flags.templates, &self.templates),
             status: cast(&flags.status, &self.status),
             ping: cast(&flags.ping, &self.ping),
             jwt: cast(&flags.jwt, &self.jwt),
@@ -94,6 +98,9 @@ impl fmt::Display for Settings {
         if self.githubci.unwrap_or(false) {
             features.push("githubci");
         }
+        if self.templates.unwrap_or(false) {
+            features.push("templates");
+        }
         if self.status.unwrap_or(false) {
             features.push("status");
         }
@@ -114,6 +121,7 @@ impl Into<Context> for Settings {
         ctxt.insert("honeycomb", &self.honeycomb.unwrap_or(false));
         ctxt.insert("selftest", &self.selftest.unwrap_or(false));
         ctxt.insert("githubci", &self.githubci.unwrap_or(false));
+        ctxt.insert("templates", &self.templates.unwrap_or(false));
         ctxt.insert("status", &self.status.unwrap_or(false));
         ctxt.insert("ping", &self.ping.unwrap_or(false));
         ctxt.insert("jwt", &self.jwt.unwrap_or(false));

--- a/templates/middleware.js
+++ b/templates/middleware.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const boltzmann = require('./boltzmann')
+
 function setupMiddlewareFunc(/* your config */) {
   // startup configuration goes here
   return function createMiddlewareFunc(next) {
@@ -16,4 +18,15 @@ function setupMiddlewareFunc(/* your config */) {
   }
 }
 
-module.exports = [setupMiddlewareFunc]
+module.exports = {
+
+  APP_MIDDLEWARE: [
+    setupMiddlewareFunc,
+    {%- if templates %}
+    [boltzmann.middleware.template, {
+      // filters: {}, // add custom template filters
+      // tags: {}     // extend nunjucks with custom tags
+    }]
+    {%- endif %}
+  ]
+}


### PR DESCRIPTION
Changes include:

- If `require('middleware')` exports an object, we will look up `APP_MIDDLEWARE` for the middleware list
- All decorators are now exported as middleware as well.
- Adds template support via nunjucks + a mechanism for registering user-defined filters and tags.
- Adds Cookie support via `context.cookie`.