### PR TITLE
Rework the middleware concept doc

### DIFF
--- a/docs/content/concepts/context.md
+++ b/docs/content/concepts/context.md
@@ -8,3 +8,5 @@ weight=1
 When Boltzmann receives an HTTP request, it wraps the incoming [Http Request]
 in a [`Context`] object. This object is open for extension by your application:
 feel free to add properties to it in your handlers and middleware.
+
+---

--- a/docs/content/concepts/context.md
+++ b/docs/content/concepts/context.md
@@ -1,0 +1,10 @@
++++
+title="Context"
+weight=1
++++
+
+## Introduction
+
+When Boltzmann receives an HTTP request, it wraps the incoming [Http Request]
+in a [`Context`] object. This object is open for extension by your application:
+feel free to add properties to it in your handlers and middleware.

--- a/docs/content/concepts/middleware.md
+++ b/docs/content/concepts/middleware.md
@@ -148,7 +148,7 @@ module.exports = {
   anyWords
 }
 
-palindromesOnly.route = 'GET /any/:utterance'
+anyWords.route = 'GET /any/:utterance'
 function anyWords (context, { utterance }) {
   return 'yep that seems about correct'
 }

--- a/docs/content/concepts/middleware.md
+++ b/docs/content/concepts/middleware.md
@@ -179,7 +179,9 @@ module.exports = {
     three
   ]
 }
+```
 
+```javascript
 // handlers.js
 module.exports = { hello }
 
@@ -210,8 +212,9 @@ module.exports = {
     three
   ]
 }
+```
 
-// handlers.js
+```javascript
 module.exports = { hello }
 
 hello.route = 'GET /'

--- a/docs/content/concepts/middleware.md
+++ b/docs/content/concepts/middleware.md
@@ -15,13 +15,13 @@ Middleware is useful for:
 - **Attaching** domain-specific attributes to request context: if you were to
   build a pizza-ordering service, you might use middleware to attach
   `context.pizzaClient = new DominosAPIClient()`.
-- **Modifying** the response from handlers in your application. For example,
-  [you could implement middleware to handle `Accept-Encoding: gzip` ][ref-gzip].
 - **Intercepting** the request before it reaches the rest of your application,
   allowing you assert facts about request context that reaches your handlers.
   For example, you might have middleware that responds to any unauthenticated
   request with a 401. As a result of this hypothetical middleware, the handlers
   in your application can rely on the fact that the user is authenticated.
+- **Modifying** the response from handlers in your application. For example,
+  [you could implement middleware to handle `Accept-Encoding: gzip` ][ref-gzip].
 
 Middleware is Boltzmann's primary mechanism for exposing configurable behavior
 to you. It is also Boltzmann's mechanism for enabling [dependency

--- a/docs/content/concepts/middleware.md
+++ b/docs/content/concepts/middleware.md
@@ -6,9 +6,9 @@ weight=9
 ## Introduction
 
 Middleware allows you to intercept, modify, or add behavior to your
-application's request handling. Boltzmann allows you to attach middleware
-to your application to modify request handling for all handlers, or to
-individual handlers.
+application's request handling. You attach middleware to Boltzmann either to
+your application, or to individual handlers. This allows you to modify request
+handling for all, or a subset of, your handlers.
 
 Middleware is useful for:
 
@@ -16,7 +16,7 @@ Middleware is useful for:
   build a pizza-ordering service, you might use middleware to attach
   `context.pizzaClient = new DominosAPIClient()`.
 - **Modifying** the response from handlers in your application. For example,
-  [we've implemented example `gzip` middleware].
+  [we've implemented example `gzip` middleware][ref-gzip].
 - **Intercepting** the request before it reaches the rest of your application,
   allowing you assert facts about request context that reaches your handlers.
   For example, you might have middleware that responds to any unauthenticated
@@ -25,10 +25,10 @@ Middleware is useful for:
 
 Middleware is Boltzmann's primary mechanism for exposing configurable behavior
 to you. It is also Boltzmann's mechanism for enabling [dependency
-injection]. It's a powerful concept! This document will cover
-how to talk about middleware and how to attach it to your application. Other
-documents cover [how to write middleware] and [what middleware boltzmann makes
-available to your application].
+injection][ref-di]. It's a powerful concept! This document will cover how to
+talk about middleware and how to attach it to your application. Other documents
+cover [how to write middleware][ref-guide] and [what middleware boltzmann makes
+available to your application][ref-reference].
 
 > :warning: This document does not cover how to parse incoming request bodies.
 > that information is available [in the body parsing] document.
@@ -133,7 +133,9 @@ module.exports = {
 }
 ```
 
-This will register the middleware application-wide.
+This will register the middleware application-wide. Application-scope attached
+middleware will execute before Boltzmann routes the request; they will execute
+even for requests that **match no corresponding route** in your application!
 
 If, on the other hand, you need logic to be applied to **many** handlers, but not
 **all**, you may wish to attach your middleware directly to handlers:
@@ -235,6 +237,13 @@ noisily at startup!
 ## Next Steps
 
 Now that you know the vocabulary for middleware, and how and when to attach it
-to your application, it's time to write some middleware. [This guide] will take
-you through writing your first middleware. You may also be interested in reviewing
-the [built-in middleware that Boltzmann makes available]. Happy hacking!
+to your application, it's time to write some middleware. [This
+guide][ref-guide] will take you through writing your first middleware. You may
+also be interested in reviewing the [built-in middleware that Boltzmann makes
+available][ref-reference]. Happy hacking!
+
+[ref-di]: https://en.wikipedia.org/wiki/Dependency_injection
+[ref-gzip]: https://github.com/entropic-dev/boltzmann/blob/latest/examples/custom-middleware/middleware/gzip.js
+[ref-guide]: @/guides/middleware.md
+[ref-reference]: @/reference/middleware.md
+[in the body parsing]: @/concepts/body-parsing.md

--- a/docs/content/concepts/middleware.md
+++ b/docs/content/concepts/middleware.md
@@ -1,54 +1,237 @@
 +++
-title="Middleware and decorators"
+title="Middleware"
 weight=9
 +++
 
-Change the behavior of your route handlers by wrapping them in *decorators*. Change the behavior of all routes by defining *middleware*. This is an important part of Boltzmann's API and a place where it differs from Express and Connect-middleware style node frameworks. We borrow some concepts from [aspect-oriented programming](https://en.wikipedia.org/wiki/Aspect-oriented_programming) and Python [decorators](https://en.wikipedia.org/wiki/Aspect-oriented_programming), so if you've used frameworks like Django you'll find this approach familiar.
+## Introduction
 
-Decorators and middleware have the same API. The difference is that "middlewares" are set up for the whole application: they apply to every route. Decorators are applied to only the routes that request them. Use a decorator when you want to require, for example, administrator-only access to a set of routes, or when you'd like to lookup a user object from a session cookie and put it onto your context. Use middleware to provide useful clients for external resources to all your routes, or to compress responses when the request accept headers allow.
+Middleware allows you to intercept, modify, or add behavior to your
+application's request handling. Boltzmann allows you to attach middleware
+to your application to modify request handling for all handlers, or to
+individual handlers.
 
-Use body middleware to parse entirely new kinds of body input.
+Middleware is useful for:
 
-To add decorators to a route, add a `decorators` field. The `decorators` field must be an array of functions. They're called in the order you list them in the array. Your route handler is called last.
+- **Attaching** domain-specific attributes to request context: if you were to
+  build a pizza-ordering service, you might use middleware to attach
+  `context.pizzaClient = new DominosAPIClient()`.
+- **Modifying** the response from handlers in your application. For example,
+  [we've implemented example `gzip` middleware].
+- **Intercepting** the request before it reaches the rest of your application,
+  allowing you assert facts about request context that reaches your handlers.
+  For example, you might have middleware that responds to any unauthenticated
+  request with a 401. As a result of this hypothetical middleware, the handlers
+  in your application can rely on the fact that the user is authenticated.
 
-To set up your server with middleware, export an array of middleware where Boltzmann can find it. Boltzmann looks for middleware exported by the following two places:
+Middleware is Boltzmann's primary mechanism for exposing configurable behavior
+to you. It is also Boltzmann's mechanism for enabling [dependency
+injection]. It's a powerful concept! This document will cover
+how to talk about middleware and how to attach it to your application. Other
+documents cover [how to write middleware] and [what middleware boltzmann makes
+available to your application].
 
-- from `middleware.js` in the same directory (good for small services)
-- from `middleware/index.js`
+> :warning: This document does not cover how to parse incoming request bodies.
+> that information is available [in the body parsing] document.
 
-The scaffolding tool gives you a working `middleware.js` file.
+---
 
-What is this decorator/middleware api? A decorator takes a `next` parameter and returns a function that takes a single context `param`. Here's a generic Boltzmann middleware file, suitable to copy-n-paste to start yours:
+## What is middleware?
 
-```js
-// in middleware.js
-function setupMiddlewareFunc (/* your config */) {
-  // startup configuration goes here
-  return function createMiddlewareFunc (next) {
-    return async function inner (context) {
-      // do things like make objects to put on the context
-      // then give following middlewares a chance
-      // route handler runs last
-      // awaiting is optional, depending on what you're doing
-      const result = await next(context)
-      // do things with result here; can replace it entirely!
-      // and you're responsible for returning it
-      return result
+Middleware is a repeatable mechanism for layering handlers and allowing them
+to delegate control to inner handlers. That's kind of a mouthful!
+
+Middleware is structured like an **onion**. A single middleware is like a layer
+of the onion. When Boltzmann responds to a request, it draws a line through
+that onion. Each layer may pass control to the next layer in the onion using
+`next()`, or it can respond to the request directly, skipping the inner layers
+of the onion. For every layer the request passes through coming in, it will
+have to travel back out through in order to send a response.
+
+If you cut one of the outer layers off of an onion and take out the inside, you
+get another, smaller onion. This is analogous to Boltzmann middleware: if you
+cut a layer of middleware off of your application, you still have the other
+layers making up the application. Boltzmann uses this property to let outer
+layers of the application assert facts that inner layers may rely upon without
+knowing _how_ those facts are asserted. Concretely: if you are using redis
+middleware, every layer of your application past the redis middleware layer
+may rely on the availability of `context.redisClient`, but they are _agnostic
+of how that property came to exist and the concrete type to which it points._
+Indeed, under test, you might cut out the redis middleware and replace it with
+middleware that puts a mock redis client implementation in place!
+
+In order to talk about how to write middleware, it is handy to have a shared
+vocabulary for talking about the anatomy of a single middleware. What follows
+is a TypeScript set of definitions for middleware, and an associated example.
+Do not fret if you're not comfortable reading this syntax! After the
+example each of the types will be broken down in natural language.
+
+```typescript
+const HEADER = Symbol.for('headers')
+const STATUS = Symbol.for('status')
+
+type HttpMetadata      = {[HEADER]: {[key: string]: string}} & {[STATUS]: number};
+type UserResponse      = string | AsyncIterable<Buffer | string> | Buffer | Object;
+type BoltzmannResponse = (AsyncIterable<Buffer | string> | Buffer | Object) & HttpMetadata;
+type Handler           = (context: Context, ...args: any[]) => UserResponse | Promise<UserResponse>;
+type Next              = (context: Context, ...args: any[]) => Promise<BoltzmannResponse>;
+type Adaptor           = (next: Next) => Handler | Promise<Handler>;
+type Middleware        = (options?: Object) => Adaptor;
+
+function middleware (_options = {}) {
+  return function adaptor (next: Next): Handler {
+    return async function handler (context: Context, ...args): Promise<UserResponse> {
+      return next(context, ...args)
     }
   }
 }
-
-modules.exports = [
-    setupMiddlewareFunc
-]
 ```
 
-See `examples/middleware/` for some meatier examples. Pro tip: debugging is easier if you name each of these layers instead of using anonymous functions.
+Middleware has three parts: the outermost function receives _configuration
+options_, which it is responsible for validating. It may throw an error if bad
+options are provided, preventing the application from starting. Middleware is
+generally called _once_ at application startup. Naming this function is useful:
+the name of the middleware will be included in Honeycomb traces if that feature
+is enabled, and it will be displayed by the development-mode debugging
+middleware if a stall happens. 
 
+Middleware returns an `Adaptor` function. The `Adaptor` function receives a
+`Next` function as an argument and returns a `Handler`. Adaptors, like the
+outer middleware, are called _once_ at application startup. The `Adaptor` can
+be asynchronous! If there are asynchronous setup steps, like connecting to a
+database or reading a file from disk, they should be performed here. Again,
+this function may throw an error if configuration is bad or necessary
+resources are unavailable.
 
-## Built-in middleware
+The application will not start accepting requests until the `Adaptor` returns a
+`Handler`. The `Handler` is executed whenever your application receives an HTTP
+request; it receives a [`Context` object](@/concepts/context.md) and returns a
+[UserResponse](@/concepts/responses.md). It may call the `Next` function
+provided as an argument to the `Adaptor` function zero-to-many times. You can
+think of calling `next()` as making a request to the inner part of your
+application! `next()` will **never** throw, and the return value is guaranteed
+to have a status code and headers associated with it. The body of the `Handler`
+is where your middleware logic should be implemented.
 
-TODO: list and describe; examples of configuration
+---
 
-## Built-in body parsers
+## Attaching & Configuring Middleware
 
+Middleware may be attached in one of two places, which is referred to as the
+"scope" of the middleware. The widest scope is application-wide: if you need
+logic to be performed on every request sent to your application, you can attach
+it in `middleware.js` or `middleware/index.js` by exporting an `APP_MIDDLEWARE`
+property that points at an array of your middleware:
+
+```javascript
+// middleware/index.js
+const myMiddleware = require('./my-middleware')
+
+module.exports = {
+  APP_MIDDLEWARE: [
+    myMiddleware
+  ]
+}
+```
+
+This will register the middleware application-wide.
+
+If, on the other hand, you need logic to be applied to **many** handlers, but not
+**all**, you may wish to attach your middleware directly to handlers:
+
+```javascript
+// handlers.js
+
+module.exports = {
+  palindromesOnly,
+  anyWords
+}
+
+palindromesOnly.route = 'GET /any/:utterance'
+function anyWords (context, { utterance }) {
+  return 'yep that seems about correct'
+}
+
+const handleNonPalindromes = require('../middleware/non-palindromes')
+palindromesOnly.route = 'GET /palindromes/:utterance'
+palindromesOnly.middleware = [
+  handleNonPalindromes // highly sophisticated middleware that 404s on non-palindromes
+]
+function palindromesOnly (context, { utterance }) {
+  return 'ok ko'
+}
+```
+
+In this example, only `palindromesOnly` is guarded by the
+`handleNonPalindromes` middleware.
+
+---
+
+Both app-wide and handler-specific middleware scopes accept an `Array` of
+`Middleware`. Middleware is executed in order, and responses from inner middleware
+bubble back up the list in reverse order:
+
+```javascript
+// middleware.js
+module.exports = {
+  APP_MIDDLEWARE: [
+    one,
+    two,
+    three
+  ]
+}
+
+// handlers.js
+module.exports = { hello }
+
+hello.route = 'GET /'
+hello.middleware = [
+  four,
+  five
+]
+function hello (context) {
+  return 'six'
+}
+```
+
+In this example, a request to `GET /` will execute `one`, `two`, `three`,
+`four`, `five`, and finally respond with six. The `'six'` response will be
+received by `five`, then `four`, then `three`, and so on.
+
+If a given middleware requires additional configuration, it can be provided
+arguments by turning the entry into an array of `[Middleware, ...arguments]`,
+which will be evaluated when the application starts up:
+
+```javascript
+// middleware.js
+module.exports = {
+  APP_MIDDLEWARE: [
+    one,
+    [two, {wow: 'an argument'}], // configure "two" with additional params
+    three
+  ]
+}
+
+// handlers.js
+module.exports = { hello }
+
+hello.route = 'GET /'
+hello.middleware = [
+  [four, 'argument one', 'argument two'],
+  five
+]
+function hello (context) {
+  return 'six'
+}
+
+```
+
+Insofar as is possible, middleware _should_ be designed such that attaching
+it with no arguments is valid. If configuration is necessary, it should fail
+noisily at startup!
+
+## Next Steps
+
+Now that you know the vocabulary for middleware, and how and when to attach it
+to your application, it's time to write some middleware. [This guide] will take
+you through writing your first middleware. You may also be interested in reviewing
+the [built-in middleware that Boltzmann makes available]. Happy hacking!

--- a/docs/content/concepts/middleware.md
+++ b/docs/content/concepts/middleware.md
@@ -16,7 +16,7 @@ Middleware is useful for:
   build a pizza-ordering service, you might use middleware to attach
   `context.pizzaClient = new DominosAPIClient()`.
 - **Modifying** the response from handlers in your application. For example,
-  [we've implemented example `gzip` middleware][ref-gzip].
+  [you could implement middleware to handle `Accept-Encoding: gzip` ][ref-gzip].
 - **Intercepting** the request before it reaches the rest of your application,
   allowing you assert facts about request context that reaches your handlers.
   For example, you might have middleware that responds to any unauthenticated

--- a/docs/content/concepts/responses.md
+++ b/docs/content/concepts/responses.md
@@ -1,0 +1,28 @@
++++
+title="Responses"
+weight=2
++++
+
+## Introduction
+
+Of course, one of the most important functions of an HTTP framework
+is providing affordances for responding to incoming requests.
+
+Boltzmann aligns JavaScript function completion behaviors & types with HTTP
+semantics: values you return will generate 200 status codes, while
+thrown errors are represented as internal server errors with a 500 status
+code, if unconfigured. Application authors may configure the HTTP behavior
+of their responses by attaching metadata to them using global [symbols].
+
+```typescript
+handler.route = 'GET /'
+function handler (context: Context) {
+  return {
+    [Symbol.for('status')]: 418,
+    [Symbol.for('headers')]: {
+      'x-clacks-overhead': 'GNU/Terry Pratchett'
+    },
+    message: 'I am a teapot!'
+  }
+}
+```

--- a/docs/content/reference/middleware.md
+++ b/docs/content/reference/middleware.md
@@ -1,0 +1,66 @@
++++
+title="Middleware"
+weight=4
++++
+
+## Introduction
+
+This document covers the built-in middleware Boltzmann makes available. Some
+middleware is automatically installed by Boltzmann when scaffolded with certain
+feature flags.
+
+### User-configurable middleware
+
+#### `authenticateJWT`
+
+---
+
+#### `template`
+
+---
+
+#### `handleCORS`
+
+---
+
+#### `applyXFO`
+
+---
+
+### Automatically installed middleware
+
+#### `trace`
+
+---
+
+#### `handlePing`
+
+---
+
+#### `log`
+
+---
+
+#### `attachRedis`
+
+---
+
+#### `attachPostgres`
+
+---
+
+#### `handleStatus`
+
+---
+
+#### `devMiddleware`
+
+---
+
+#### `honeycombMiddlewareSpans`
+
+---
+
+#### `enforceInvariants`
+
+---

--- a/docs/themes/after-dark/templates/section.html
+++ b/docs/themes/after-dark/templates/section.html
@@ -1,0 +1,69 @@
+{% import "post_macros.html" as post_macros %}
+
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+      <meta http-equiv="X-UA-Compatible" content="IE=edge">
+      <meta http-equiv="content-type" content="text/html; charset=utf-8">
+
+      <!-- Enable responsiveness on mobile devices-->
+      <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
+
+      <title>{% block title %}{{ config.title }}{% endblock title %}</title>
+
+      {% if config.generate_feed %}
+        <link rel="alternate" type={% if config.feed_filename == "atom.xml" %}"application/atom+xml"{% else %}"application/rss+xml"{% endif %} title="RSS" href="{{ get_url(path=config.feed_filename) | safe }}">
+      {% endif %}
+
+      {% block css %}
+          <link rel="stylesheet" href="{{ get_url(path="site.css", trailing_slash=false) | safe }}">
+      {% endblock css %}
+
+      {% block extra_head %}
+      {% endblock extra_head %}
+    </head>
+
+    <body class="hack dark main container">
+        {% block content %}
+            {% block header %}
+                {% if config.extra.after_dark_menu %}
+                    <header>
+                        <nav itemscope itemtype="http://schema.org/SiteNavigationElement">
+                        {% for item in config.extra.after_dark_menu %}
+                            <a itemprop="url"
+                               class="{% if item.url | replace(from="$BASE_URL", to=config.base_url) == current_url %}active{% endif %}"
+                               href="{{ item.url | safe | replace(from="$BASE_URL", to=config.base_url) }}">
+                                <span itemprop="name">{{ item.name }}
+                                </span></a>
+                        {% endfor %}
+                        </nav>
+                    </header>
+                {% endif %}
+            {% endblock header %}
+
+            <main>
+                {% if config.extra.after_dark_title %}
+                    <header>
+                        <h1>{{ config.extra.after_dark_title }}</h1>
+                    </header>
+                {% endif %}
+                {% for page in paginator.pages %}
+                    {{ post_macros::page_in_list(page=page) }}
+                {% endfor %}
+
+                <nav>
+                  <p>
+                    {% if paginator.previous %}
+                      <a href="{{ paginator.previous }}">&laquo; Previous</a> |
+                    {% endif %}
+                    <span>Page {{ paginator.current_index }} of {{ paginator.number_pagers }}</span>
+                    {% if paginator.next %}
+                      | <a href="{{ paginator.next }}">Next &raquo;</a>
+                    {% endif %}
+                  </p>
+                </nav>
+            </main>
+        {% endblock content %}
+    </body>
+
+</html>


### PR DESCRIPTION
Link off to nearly-empty Context, Response, and middleware reference documentation. Use TypeScript type definitions to give us names for the various components of a given middleware. Use an onion analogy, because I can't be helped. An illustration of this would be useful.

Refrain from mentioning decorators, since we want to move away from them. (We might add an admonition about their presence.)

There are dangling links in the text, which represent a... sort of TODO list, to be honest.

This also adds a "section.html" template to the after-dark, which is just a copy of "index.html".

(Also, work around a strange Zola bug where a mid-codefence `// handlers.js` caused zola to hang.)