### PR TITLE
feat: csrf protection middleware

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -6,7 +6,7 @@ function run_selftest() {
   rm -rf tmp
   mkdir tmp
 
-  cargo run -- --selftest --jwt --templates --force tmp
+  cargo run -- --selftest --force tmp
   tmp/node_modules/.bin/tap tmp/test.js
 }
 
@@ -19,14 +19,14 @@ function run_startup() {
   echo 'running the server'
   PORT=8080 tmp/boltzmann.js &
   bg &> /dev/null || result=1
-  pid=$!
 
   sleep 2 # ha ha ha ha ha
   echo 'attempting to curl'
   result=$(curl -sL http://127.0.0.1:8080/hello/world)
 
   echo 'stopping the server'
-  kill $pid
+  pkill -f "node tmp/boltzmann.js"
+  wait
 
   if [ "$result" != "hello world" ]; then
     echo -e "expected \"hello world\", got \"$result\""
@@ -54,7 +54,7 @@ function run_examples() {
 
     popd
     git checkout $example
-    git clean -f $example
+    git clean -f -q $example
   done
 }
 

--- a/src/dependencies.ron
+++ b/src/dependencies.ron
@@ -3,7 +3,7 @@
     name: "are-we-dev",
     version: "^1.0.0",
     kind: Normal,
-    preconditions:None
+    preconditions: None
   ),
   DependencySpec(
     name: "nunjucks",
@@ -18,73 +18,79 @@
     name: "culture-ships",
     version: "^1.0.0",
     kind: Normal,
-    preconditions: None
+    preconditions:  None
   ),
   DependencySpec(
     name: "find-my-way",
     version: "^2.2.1",
     kind: Normal,
-    preconditions:None
+    preconditions: None
   ),
   DependencySpec(
     name: "bole",
     version: "^4.0.0",
     kind: Normal,
-    preconditions:None
+    preconditions: None
   ),
   DependencySpec(
     name: "jsonwebtoken",
     version: "^8.5.1",
     kind: Normal,
-    preconditions:Some(When(feature: Some("jwt"),if_not_present: []))
+    preconditions: Some(When(feature: Some("jwt"),if_not_present: []))
   ),
   DependencySpec(
     name: "ajv",
     version: "^6.12.2",
     kind: Normal,
-    preconditions:None
+    preconditions: None
   ),
   DependencySpec(
     name: "dotenv",
     version: "^8.2.0",
     kind: Normal,
-    preconditions:None
+    preconditions: None
   ),
   DependencySpec(
     name: "accepts",
     version: "^1.3.7",
     kind: Normal,
-    preconditions:None
+    preconditions: None
+  ),
+  DependencySpec(
+    name: "csrf",
+    version: "^3.1.0",
+    kind: Normal,
+    preconditions: Some(When(feature: Some("csrf"),if_not_present: []))
   ),
   DependencySpec(
     name: "honeycomb-beeline",
     version: "^2.1.1",
     kind: Normal,
-    preconditions:Some(When(feature: Some("honeycomb"),if_not_present: []))
+    preconditions: Some(When(feature: Some("honeycomb"),if_not_present: []))
   ),
   DependencySpec(
     name: "on-headers",
     version: "^1.0.2",
     kind: Normal,
-    preconditions:Some(When(  feature: Some("honeycomb"), if_not_present: [] ))
+    preconditions: Some(When(  feature: Some("honeycomb"), if_not_present: [] ))
   ),
   DependencySpec(
     name: "pg",
     version: "^8.2.1",
     kind: Normal,
-    preconditions:Some(When(  feature: Some("postgres"),if_not_present: [] ))
+    preconditions: Some(When(  feature: Some("postgres"),if_not_present: [] ))
   ),
   DependencySpec(
     name: "handy-redis",
     version: "^1.8.1",
     kind: Normal,
-    preconditions:Some(When( feature: Some("redis"),if_not_present: [] ))
+    preconditions: Some(When( feature: Some("redis"),if_not_present: [] ))
   ),
   DependencySpec(
     name: "redis",
     version: "^3.0.2",
     kind: Normal,
-    preconditions:Some(When(feature: Some("redis"),if_not_present: []))
+    preconditions: Some(When(feature: Some("redis"),if_not_present: []))
   ),
 
   DependencySpec(
@@ -98,55 +104,55 @@
     name: "tap",
     version: "^14.10.7",
     kind: Development,
-    preconditions:None
+    preconditions: None
   ),
   DependencySpec(
     name: "@hapi/shot",
     version: "^4.1.2",
     kind: Development,
-    preconditions:None
+    preconditions: None
   ),
   DependencySpec(
     name: "bistre",
     version: "^1.0.1",
     kind: Development,
-    preconditions:None
+    preconditions: None
   ),
   DependencySpec(
     name: "eslint",
     version: "^7.1.0",
     kind: Development,
-    preconditions:None
+    preconditions: None
   ),
   DependencySpec(
     name: "@typescript-eslint/parser",
     version: "^3.1.0",
     kind: Development,
-    preconditions:None
+    preconditions: None
   ),
   DependencySpec(
     name: "@typescript-eslint/eslint-plugin",
     version: "^3.1.0",
     kind: Development,
-    preconditions:None
+    preconditions: None
   ),
   DependencySpec(
     name: "eslint-config-prettier",
     version: "^6.11.0",
     kind: Development,
-    preconditions:None
+    preconditions: None
   ),
   DependencySpec(
     name: "eslint-plugin-prettier",
     version: "^3.1.3",
     kind: Development,
-    preconditions:None
+    preconditions: None
   ),
   DependencySpec(
     name: "prettier",
     version: "^2.0.5",
     kind: Development,
-    preconditions:None
+    preconditions: None
   ),
 
 ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,9 @@ pub struct Flags {
     #[structopt(long, help = "Enable jwt middleware")]
     jwt: Option<Option<Flipper>>,
 
+    #[structopt(long, help = "Enable csrf protection middleware")]
+    csrf: Option<Option<Flipper>>,
+
     #[structopt(long, help = "Update a git-repo destination even if there are changes")]
     force: bool, // for enemies
 

--- a/templates/boltzmann.js
+++ b/templates/boltzmann.js
@@ -28,6 +28,10 @@ const isDev = require('are-we-dev')
 const fmw = require('find-my-way')
 const accepts = require('accepts')
 const fs = require('fs').promises
+// {% if csrf %}
+const crypto = require('crypto')
+const CsrfTokens = require('csrf')
+// {% endif %}
 const http = require('http')
 const bole = require('bole')
 const os = require('os')
@@ -577,13 +581,103 @@ function applyHeaders (headers = {}) {
 
 const applyXFO = (mode) => applyHeaders({ 'x-frame-options': mode })
 
-function applyCSRF () {
+// {% if csrf %}
+// csrf protection middleware
+function signCookie(value, secret) {
+  return `${value}.${crypto.createHmac('sha256', secret).update(value).digest('base64')}`
+}
+
+function checkCookieSignature(input, secret) {
+  if (!input) {
+    return false
+  }
+  const [ message, signature ] = input.split('.', 2)
+  const valid = signCookie(message, secret)
+  return crypto.timingSafeEqual(Buffer.from(input), Buffer.from(valid)) ? message : false
+}
+
+const READ_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+
+function applyCSRF ({
+  cookieSecret = process.env.COOKIE_SECRET,
+  csrfCookie = '_csrf',
+  param = '_csrf',
+  header = 'csrf-token'
+} = {}) {
+
+  if (!cookieSecret) {
+    throw new Error('You cannot use CSRF middleware without providing a secret for signing cookies')
+  }
+
   return next => {
+    const tokens = new CsrfTokens()
     return async function csrf (context) {
+
+      function generateNewSecretCookie () {
+        const newSecret = tokens.secretSync()
+        const signed = signCookie(newSecret, cookieSecret)
+        context.cookie.set(csrfCookie, signed)
+        return newSecret
+      }
+
+      function fetchSecretFromCookie () {
+        const candidate = context.cookie.get(csrfCookie)
+        if (!candidate) {
+          return undefined
+        }
+        return checkCookieSignature(candidate.value, cookieSecret)
+      }
+
+      async function findToken (context) {
+        const body = await context.body
+        return (body && body[param]) || context.headers[header]
+      }
+
+      // Handlers can call this to get a token to use on relevant requests.
+      // It creates a token-generating secret for the user if they don't have one
+      // already, and makes a new token.
+      function csrfToken () {
+        const freshSecret = fetchSecretFromCookie()
+
+        // We might be coming through here more than once.
+        // Re-use the token if we can, but generate a new one if the secret in the cookie changed.
+        if (token && freshSecret === secret) {
+          return token
+        }
+
+        if (!freshSecret) {
+          secret = generateNewSecretCookie() // changes value in the closure
+        }
+
+        token = tokens.create(secret) // changes value in the closure
+        return token
+      }
+
+      // set up context for handler, with intentional hoist
+      context.csrfToken = csrfToken
+      var secret = fetchSecretFromCookie()
+      var token
+
+      if (!secret) {
+        secret = generateNewSecretCookie()
+      }
+
+      if (READ_METHODS.has(context.method)) {
+        return next(context)
+      }
+
+      const tk = await findToken(context)
+      if (!tokens.verify(secret, tk)) {
+        throw Object.assign(new Error('Invalid CSRF token'), {
+          [Symbol.for('status')]: 403
+        })
+      }
+
       return next(context)
     }
   }
 }
+// {% endif %}
 
 // {% if jwt %}
 function authenticateJWT ({
@@ -1244,7 +1338,10 @@ exports.middleware = {
 // {% endif %}
   handleCORS,
   applyXFO,
-  ...exports.decorators // forwarding these here.
+// {% if csrf %}
+  applyCSRF,
+// {% endif %}
+...exports.decorators // forwarding these here.
 }
 
 // {% if not selftest %}
@@ -1336,7 +1433,7 @@ if (require.main === module) {
 
   test('200 ok: json; returns expected headers and response', async assert => {
     const handler = () => {
-      return {message: 'hello world'}
+      return { message: 'hello world' }
     }
     handler.route = 'GET /'
     const server = await main({
@@ -2172,13 +2269,8 @@ if (require.main === module) {
 
     handler.route = 'GET /'
     const server = await main({
-      middleware: [
-        [applyHeaders, { currency: 'zorkmid' }
-        ]
-      ],
-      handlers: {
-        handler
-      }
+      middleware: [[applyHeaders, { currency: 'zorkmid' }]],
+      handlers: { handler }
     })
 
     const [onrequest] = server.listeners('request')
@@ -2187,6 +2279,7 @@ if (require.main === module) {
       url: '/'
     })
 
+    assert.equal(response.payload, 'woot')
     assert.equal(response.headers.currency, 'zorkmid')
   })
 
@@ -2214,6 +2307,210 @@ if (require.main === module) {
     assert.equal(response.headers['x-frame-options'], 'DENY')
   })
 
+  test('csrf middleware requires a signing secret', async assert => {
+    let server, error
+    let threw = false
+    try {
+      server = await main({
+        middleware: [ [ applyCSRF, {} ],],
+        handlers: { }
+      })
+    } catch (ex) {
+      threw = true
+      error = ex
+    }
+
+    assert.ok(threw)
+    assert.ok(/a secret for signing cookies/.test(error.message))
+  })
+
+  test('csrf middleware adds a token generator to the context', async assert => {
+    let t
+    const handler = async context => {
+      assert.equal(typeof context.csrfToken, 'function')
+      const t1 = context.csrfToken()
+      const t2 = context.csrfToken()
+      assert.equal(t1, t2)
+      return t1
+    }
+
+    handler.route = 'GET /'
+    const server = await main({
+      middleware: [ [ applyCSRF, { cookieSecret: 'not-very-secret' } ],],
+      handlers: { handler }
+    })
+
+    const [onrequest] = server.listeners('request')
+    const response = await shot.inject(onrequest, {
+      method: 'GET',
+      url: '/'
+    })
+    assert.equal(typeof response.payload, 'string')
+  })
+
+  test('csrf middleware enforces presence of token on mutations', async assert => {
+    let called = 0
+    const handler = async context => {
+      called++
+      return 'no tokens at all'
+    }
+
+    handler.route = 'PUT /'
+    const server = await main({
+      middleware: [ [ applyCSRF, { cookieSecret: 'not-very-secret' } ],],
+      handlers: { handler }
+    })
+
+    const [onrequest] = server.listeners('request')
+    const response = await shot.inject(onrequest, {
+      method: 'PUT',
+      url: '/',
+      payload: { text: 'I am quite tokenless.' }
+    })
+
+    assert.equal(response.statusCode, 403)
+    assert.ok(/Invalid CSRF token/.test(response.payload))
+    assert.equal(called, 0)
+  })
+
+  test('csrf middleware accepts valid token in body', async assert => {
+    const _c = require('cookie')
+
+    let called = 0
+    const handler = async context => {
+      called++
+      return 'my token is good'
+    }
+
+    const cookieSecret = 'avocados-are-delicious'
+    const tokens = new CsrfTokens()
+    const userSecret = tokens.secretSync()
+    const token = tokens.create(userSecret)
+    const signedUserSecret = signCookie(userSecret, cookieSecret)
+
+    handler.route = 'PUT /'
+    const server = await main({
+      middleware: [ [ applyCSRF, { cookieSecret } ],],
+      handlers: { handler }
+    })
+
+    const [onrequest] = server.listeners('request')
+    const response = await shot.inject(onrequest, {
+      method: 'PUT',
+      url: '/',
+      headers: { cookie: _c.serialize('_csrf', signedUserSecret) },
+      payload: { '_csrf': token }
+    })
+
+    assert.equal(called, 1)
+    assert.equal(response.statusCode, 200)
+    assert.equal(response.payload, 'my token is good')
+  })
+
+  test('csrf middleware accepts valid token in headers', async assert => {
+    const _c = require('cookie')
+
+    let called = 0
+    const handler = async context => {
+      called++
+      return 'my header token is good'
+    }
+
+    const cookieSecret = 'avocados-are-delicious'
+    const tokens = new CsrfTokens()
+    const userSecret = tokens.secretSync()
+    const signedUserSecret = signCookie(userSecret, cookieSecret)
+    const token = tokens.create(userSecret)
+
+    handler.route = 'PUT /'
+    const server = await main({
+      middleware: [ [ applyCSRF, { cookieSecret, header: 'my-header' } ],],
+      handlers: { handler }
+    })
+
+    const [onrequest] = server.listeners('request')
+    const response = await shot.inject(onrequest, {
+      method: 'PUT',
+      url: '/',
+      headers: {
+        cookie: _c.serialize('_csrf', signedUserSecret),
+        'my-header': token
+      },
+      payload: {}
+    })
+
+    assert.equal(called, 1)
+    assert.equal(response.statusCode, 200)
+    assert.equal(response.payload, 'my header token is good')
+  })
+
+  test('csrf middleware rejects bad tokens', async assert => {
+    const _c = require('cookie')
+
+    let called = 0
+    const handler = async context => {
+      called++
+      return 'my body token is bad'
+    }
+
+    const cookieSecret = 'avocados-are-delicious'
+    const tokens = new CsrfTokens()
+    const userSecret = tokens.secretSync()
+    const signedUserSecret = signCookie(userSecret, cookieSecret)
+    const token = tokens.create(userSecret)
+
+    handler.route = 'PUT /'
+    const server = await main({
+      middleware: [ [ applyCSRF, { cookieSecret } ],],
+      handlers: { handler }
+    })
+
+    const [onrequest] = server.listeners('request')
+    const response = await shot.inject(onrequest, {
+      method: 'PUT',
+      url: '/',
+      headers: { cookie: _c.serialize('_csrf', signedUserSecret) },
+      payload: { _csrf: 'bad-token-dudes' }
+    })
+
+    assert.equal(response.statusCode, 403)
+    assert.ok(/Invalid CSRF token/.test(response.payload))
+    assert.equal(called, 0)
+  })
+
+  test('csrf middleware ignores secrets with bad signatures', async assert => {
+    const _c = require('cookie')
+
+    let called = 0
+    const handler = async context => {
+      called++
+      return 'my signature is bad'
+    }
+
+    const cookieSecret = 'avocados-are-delicious'
+    const tokens = new CsrfTokens()
+    const userSecret = tokens.secretSync()
+    const signedUserSecret = signCookie(userSecret, 'cilantro-is-great')
+    const token = tokens.create(userSecret)
+
+    handler.route = 'PUT /'
+    const server = await main({
+      middleware: [ [ applyCSRF, { cookieSecret } ],],
+      handlers: { handler }
+    })
+
+    const [onrequest] = server.listeners('request')
+    const response = await shot.inject(onrequest, {
+      method: 'PUT',
+      url: '/',
+      headers: { cookie: _c.serialize('_csrf', signedUserSecret) },
+      payload: { _csrf: 'bad-token-dudes' }
+    })
+
+    assert.equal(response.statusCode, 403)
+    assert.ok(/Invalid CSRF token/.test(response.payload))
+    assert.equal(called, 0)
+  })
 
 }
 // {% endif %}

--- a/templates/boltzmann.js
+++ b/templates/boltzmann.js
@@ -634,7 +634,7 @@ function applyCSRF ({
       // Handlers can call this to get a token to use on relevant requests.
       // It creates a token-generating secret for the user if they don't have one
       // already, and makes a new token.
-      function csrfToken (refresh = false) {
+      function csrfToken ({refresh = false} = {}) {
         const freshSecret = fetchSecretFromCookie()
 
         // We might be coming through here more than once.
@@ -2359,7 +2359,9 @@ if (require.main === module) {
     const handler = async context => {
       const t1 = context.csrfToken()
       const t2 = context.csrfToken({ refresh: true})
+      const t3 = context.csrfToken({ refresh: false})
       assert.notEqual(t1, t2)
+      assert.equal(t2, t3)
       return "my tokens are fresh"
     }
 

--- a/templates/boltzmann.js
+++ b/templates/boltzmann.js
@@ -2414,7 +2414,7 @@ if (require.main === module) {
 
     const cookieSecret = 'avocados-are-delicious'
     const tokens = new CsrfTokens()
-    const userSecret = tokens.secretSync()
+    const userSecret = await tokens.secret()
     const token = tokens.create(userSecret)
     const signedUserSecret = signCookie(userSecret, cookieSecret)
 

--- a/templates/eslintrc.js
+++ b/templates/eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
   },
   extends: ['plugin:@typescript-eslint/recommended', 'prettier/@typescript-eslint', 'plugin:prettier/recommended'],
   rules: {
-    '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: 'Context' }],
+    '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: '(Context|_)' }],
     '@typescript-eslint/no-var-requires': [0],
   },
 }


### PR DESCRIPTION
This implementation uses the double-submit pattern to dodge around having to store state in a user session, since we don't have a built-in session store yet. It uses the same approach as the connect-style `csurf` middleware, and
bases its implementation on the same underlying random token implementation. We store a secret in a signed cookie for the user, and verify that a) the cookie signature is good, and that b) the submitted token is valid for that secret.

Configuration options:

* `cookieSecret`: the secret used to sign the cookie
* `param`: a body param to look for the csrf token in
* `header`: a response header to look for the csrf token in; is consulted first if both are used

Wrote tests for it that verify we ignore read http verbs, we enforce it on write verbs, we look in the body param specified, we look in the header specified, and we bounce on bad tokens & bad cookie signatures.

Added this as a command-line option. Our current approach to feature options is now officially unwieldy and the next one will trigger me to rewrite it.

Tweaked `--selftest` so it turns on all options, and cleaned up the self test. Also, made the test script more reliable in my testing by using pkill to detect boltzmann processes.

Wrote tests for `applyHeaders` and `applyXFO` and made `applyXFO` work.