### PR TITLE
feat: back-port a url setter for the context object

### DIFF
--- a/templates/boltzmann.js
+++ b/templates/boltzmann.js
@@ -179,6 +179,11 @@ class Context {
     return this._parsedUrl
   }
 
+  set url(value) {
+    this._parsedUrl = null
+    this.request.url = value
+  }
+
   get query () {
     return Object.fromEntries(this.url.searchParams)
   }


### PR DESCRIPTION
This was invented to implement the route-prefix feature in payments2020.