### PR TITLE
Add debug template, static asset middleware, tmpl context mw.

### DIFF
--- a/src/dependencies.ron
+++ b/src/dependencies.ron
@@ -113,6 +113,24 @@
     preconditions: None
   ),
   DependencySpec(
+    name: "stackman",
+    version: "^4.0.1",
+    kind: Development,
+    preconditions: Some(When(
+      feature: Some("templates"),
+      if_not_present: []
+    ))
+  ),
+  DependencySpec(
+    name: "get-function-location",
+    version: "^2.0.0",
+    kind: Development,
+    preconditions: Some(When(
+      feature: Some("templates"),
+      if_not_present: []
+    ))
+  ),
+  DependencySpec(
     name: "@hapi/shot",
     version: "^4.1.2",
     kind: Development,


### PR DESCRIPTION
The debug template is inspired by Django. It includes:

- Relevant configuration information about the failed request
- A copy-and-paste view of the error.
- Remediation recommendations for 404 errors and missing template errors.
- VSCode links to relevant functions.
- Stack trace context.
- Request and response information.
- If configured, a link to the honeycomb trace.

Notable missing features / room for improvement:

- Handler middleware is not VSCode-linked.
- Request body information is not collected/displayed.
- Uses tachyons served from unpkg, should likely vendor this content.
- We should check for `instanceof NoMatchError` outside of the debug template and create a context var for it, vs. including `__noMatch` as part of the response data. (It's just a little untidy.)
- We prrrrrobably should move the debug template to a separate file and include it literally.