### PR TITLE
Some documentation work on the cli options & the landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,45 +25,35 @@ For full Boltzmann docs, visit [the documentation site](https://www.boltzmann.de
 
 If you prefer to look at working example code, we've provided examples in the [`./examples`](https://github.com/entropic-dev/boltzmann/tree/latest/examples) directory of this repo.
 
-To get started with Boltzmann, run the `boltzmann` command-line tool. You can get it from [the releases page][https://github.com/entropic-dev/boltzmann/releases] or run it via `npx boltzmann-cli`. The tool is responsible for initializing a new Boltzmann project as well as keeping it up to date. You enable or disable specific Boltzmann features using the tool.
+To scaffold a new service with Boltzmann, run the `boltzmann` command-line tool. You can get it from [the releases page][https://github.com/entropic-dev/boltzmann/releases] or run it via `npx boltzmann-cli`. (We prebuild for Mac OS, Windows, and GNU Linuxes.) The tool is responsible for initializing a new Boltzmann project as well as keeping it up to date. You enable or disable specific Boltzmann features using the tool.
 
 For example, to scaffold with the defaults:
 
 ```shell
-projects|⇒ npx boltzmann-cli ./hello
+projects|⇒ npx boltzmann-cli hello
 ```
 
-<img src="docs/content/reference/cli-example.jpg" alt="cli example" width="1000">
-
-A complete Boltzmann hello world is provided for you.
+A complete project is provided for you, with useful package run scripts and linting.
 
 ```shell
-hello|⇒ ls
-boltzmann.js*  handlers.js  middleware.js  node_modules/  package-lock.json  package.json
+code|⇒ cd hello/
+hello|⇒ ls -alF
+.rw-r--r--  427 cj  7 Sep 17:15 .eslintrc.js
+drwxr-xr-x    - cj  7 Sep 17:15 .github/
+.rw-r--r--  136 cj  7 Sep 17:15 .prettierrc.js
+.rwxr-xr-x  20k cj  7 Sep 17:15 boltzmann.js*
+.rw-r--r--  262 cj  7 Sep 17:15 handlers.js
+.rw-r--r-- 1.3k cj  7 Sep 17:15 middleware.js
+drwxr-xr-x    - cj  7 Sep 17:15 node_modules/
+.rw-r--r-- 155k cj  7 Sep 17:15 package-lock.json
+.rw-r--r--  999 cj  7 Sep 17:15 package.json
 ```
 
-Take a look at `handlers.js`:
-
-```js
-import { Context } from './boltzmann.js' // optionally pull in typescript definition
-
-greeting.route = 'GET /hello/:name'
-export async function greeting(/** @type {Context} */ context) {
-    return `hello ${context.params.name}`
-}
-
-module.exports = {
-  greeting
-}
-```
-
-To respond from a Boltzmann handler, you return a value. To return an error, you throw. Boltzmann will map values and exceptions to http semantics.
-
-To run: `./boltzmann.js`. And to view the response: `curl http://localhost:5000/hello/world`
+To run: `./boltzmann.js`. And to view the response: `curl http://localhost:5000/hello/world`. Want to know more? [Check the docs!](https://www.boltzmann.dev/en/docs/v0.1.2/)
 
 ## Team
 
-Who's the "we" in this document? [@ceejbot](https://github.com/ceejbot) and [@chrisdickinson](https://github.com/chrisdickinson).
+Boltzmann is a joint venture of [@ceejbot](https://github.com/ceejbot) and [@chrisdickinson](https://github.com/chrisdickinson).
 
 ## LICENCE
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -7,17 +7,17 @@ sort_by = "weight"
 
 # Getting started
 
-Boltzmann is a node http server framework that uses the same building blocks as many other frameworks, using well-tested libraries like the ones from the jshttp project. It makes some choices that are notably different from many other node frameworks, and you'll want to know about these choices even if you're an experienced node developer.
+Boltzmann is a node http server framework that uses the same building blocks as many other frameworks, using well-tested libraries like the ones from the [jshttp project](https://jshttp.github.io), which support Express. It makes some choices that are notably different from many other node frameworks, and you'll want to know about these choices even if you're an experienced node developer.
 
 The first difference you're likely to notice is that Boltzmann is not a versioned dependency of your application. It's implemented in a single file that lives alongside your code. Its dependencies are dependencies of your project. This decision makes some tradeoffs that we found useful in our projects: we can choose when to upgrade core dependencies, and aren't tied to waiting for the framework to update. We can also choose to modify Boltzmann's source code directly if the project needs this, at the cost of no longer being able to update automatically.
 
 As a result, you don't install Boltzmann using a package manager like yarn. Instead, you scaffold a Boltzmann project using its templating tool. The easiest way to run this tool is to use `npx`: `npx boltzmann-cli --help`. You can also build the tool yourself from source if you have the Rust toolchain, or [install a pre-built release](https://github.com/entropic-dev/boltzmann/releases). This tool generates a single javascript file with all of Boltzmann's implementation, and some scaffolding for a full Boltzmann app if it's not already present. Passing options to the tool enables or disables specific Boltzmann features. The tool is safe to re-run, provided you are running it in a versioned git directory.
 
-The next major difference boltzmann has from frameworks like Express is its [approach to middleware](@/concepts/middleware.md). It doesn't use the Connect-style API and it doesn't offer lifecycle hooks. Instead, Boltzmann uses an approach borrowed from aspect-oriented programming. You'll want to spend time with the middleware documentation, because middleware is how you'll add any functionality to your service that's used by more than one route handler. You can also change Boltzmann's core behavior with custom middleware!
+The next major difference boltzmann has from frameworks like Express is its [approach to middleware](@/concepts/middleware.md). It doesn't use the Connect-style API and it doesn't offer lifecycle hooks. Instead, Boltzmann uses an approach borrowed from aspect-oriented programming, which you'll be familiar with if you've been using frameworks like React. Middleware is how you'll implement new behavior that can be re-used in your route handlers. You can also change Boltzmann's core behavior with custom middleware!
 
-The third difference is in the API of Boltzmann's [route handers](@/concepts/routing.md). To respond with data from a route, return the data. Boltzmann will set content type headers appropriately. To respond with an error, throw: Boltzmann will translate to http semantics automatically. (To control how thrown errors are translated, you can write middleware!) Learn more about building responses in the [responses documentation](@/concepts/responses.md).
+The third difference is in the API of Boltzmann's [route handers](@/concepts/routing.md). To respond with data from a route, return the data. Boltzmann sets content type headers based on what you return, deferring to any headers you provide in the `headers` symbol on your response. To respond with an error, throw: Boltzmann will translate to http semantics automatically. (To control how thrown errors are translated, you can write middleware!) Learn more about building responses in the [responses documentation](@/concepts/responses.md).
 
-Boltzmann also relies on a little bit of convention to simplify configuration. For instance, it assumes that all route handlers are exported from `handlers.js` or a `handlers/` directory in the same level of the project.
+Boltzmann also relies on a little bit of convention to simplify configuration. For instance, it assumes that all route handlers are exported from `handlers.js` or a `handlers/` directory in the same level of the project. The same is true for middleware: you can move to exports from a `middleware/` directory if you outgrow the initial `middlware.js` file.
 
 ## Hello world
 
@@ -76,7 +76,7 @@ module.exports = {
 
 To run: `./boltzmann.js`. And to view the response: `curl http://localhost:5000/hello/world`
 
-The [context object](@/concepts/context.md) is where Boltzmann puts all data it derives from the initial request. It expects you to modify the context object in middleware: it is there to hold data you find useful through the request lifecycle. The raw node request and response objects are available on the context object if you need them, but we suggest you avoid modifying them directly.
+The [context object](@/concepts/context.md) is where Boltzmann puts all data it derives from the initial request. It expects you to modify the context object in middleware: it is there to hold data you find useful through the request lifecycle. The raw node request object is available on the context object if you need it, but we suggest you avoid modifying it directly. In particular, you might break body parsing middleware.
 
 The default scaffolded project also provides a commented `middleware.js` file to help you write your first middlewares. And finally, a linter is configured for you.
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -5,40 +5,32 @@ description = "Introduction to Boltzmann"
 sort_by = "weight"
 +++
 
-# Boltzmann: an introduction
+# Getting started
 
-Boltzmann is a JavaScript framework for writing web servers. It is implemented in a single file that lives alongside your code. Boltzmann is focused on delivering a great developer experience and makes its tradeoffs with that goal in mind.
+Boltzmann is a node http server framework that uses the same building blocks as many other frameworks, using well-tested libraries like the ones from the jshttp project. It makes some choices that are notably different from many other node frameworks, and you'll want to know about these choices even if you're an experienced node developer.
 
-Our design goals:
+The first difference you're likely to notice is that Boltzmann is not a versioned dependency of your application. It's implemented in a single file that lives alongside your code. Its dependencies are dependencies of your project. This decision makes some tradeoffs that we found useful in our projects: we can choose when to upgrade core dependencies, and aren't tied to waiting for the framework to update. We can also choose to modify Boltzmann's source code directly if the project needs this, at the cost of no longer being able to update automatically.
 
-- Make all return values from route handlers and middlewares be valid responses, mapping to http semantics.
-- Prefer zero-cost abstractions: pay for what you use and nothing more, including in installation and startup time.
-- Use global types, no special response types.
-- Only modify objects we provide; do not rely on modifications to node's request & response objects.
-- Provide pluggable behavior for body-parsing and middleware, with good defaults.
-- Use only minimal, well-vetted dependencies.
-- Bake in observability (optionally), via [Honeycomb](https://honeycomb.io) tracing.
-- Rely on a little bit of documented convention to avoid configuration.
-- Making throwing Boltzmann away if you need to move on _possible_.
+As a result, you don't install Boltzmann using a package manager like yarn. Instead, you scaffold a Boltzmann project using its templating tool. The easiest way to run this tool is to use `npx`: `npx boltzmann-cli --help`. You can also build the tool yourself from source if you have the Rust toolchain, or [install a pre-built release](https://github.com/entropic-dev/boltzmann/releases). This tool generates a single javascript file with all of Boltzmann's implementation, and some scaffolding for a full Boltzmann app if it's not already present. Passing options to the tool enables or disables specific Boltzmann features. The tool is safe to re-run, provided you are running it in a versioned git directory.
 
-Boltzmann provides Typescript definitions for its exports, for your development convenience, but it does not require you to opt-in to Typescript or do any transpilation. We'd like you to be able to run Boltzmann apps under deno or in a web worker some day, so we make API choices that move us toward that goal.
+The next major difference boltzmann has from frameworks like Express is its [approach to middleware](@/concepts/middleware.md). It doesn't use the Connect-style API and it doesn't offer lifecycle hooks. Instead, Boltzmann uses an approach borrowed from aspect-oriented programming. You'll want to spend time with the middleware documentation, because middleware is how you'll add any functionality to your service that's used by more than one route handler. You can also change Boltzmann's core behavior with custom middleware!
 
-Who's the "we" in this document? @ceejbot and @chrisdickinson.
+The third difference is in the API of Boltzmann's [route handers](@/concepts/routing.md). To respond with data from a route, return the data. Boltzmann will set content type headers appropriately. To respond with an error, throw: Boltzmann will translate to http semantics automatically. (To control how thrown errors are translated, you can write middleware!) Learn more about building responses in the [responses documentation](@/concepts/responses.md).
 
-<!-- more -->
+Boltzmann also relies on a little bit of convention to simplify configuration. For instance, it assumes that all route handlers are exported from `handlers.js` or a `handlers/` directory in the same level of the project.
 
-To get started with Boltzmann, run the `boltzmann` command-line tool. You can get it from [the releases page][https://github.com/entropic-dev/boltzmann/releases] or run it via `npx boltzmann-cli`. The tool is responsible for initializing a new Boltzmann project as well as keeping it up to date. You enable or disable specific Boltzmann features using the tool.
+## Hello world
 
-For example, to scaffold with the defaults:
+Let's look at a hello-world project.
 
 ```shell
-projects|⇒ npx boltzmann-cli ./hello
-npx: installed 1 in 1.511s
-Scaffolding a Boltzmann service in ./hello
+code|⇒ npx boltzmann-cli hello
+Scaffolding a Boltzmann service in /Users/cj/code/hello
     initializing a new NPM package...
     writing boltzmann files...
     updating dependencies...
         adding are-we-dev @ ^1.0.0
+        adding uuid @ ^8.3.0
         adding culture-ships @ ^1.0.0
         adding find-my-way @ ^2.2.1
         adding bole @ ^4.0.0
@@ -57,10 +49,10 @@ Scaffolding a Boltzmann service in ./hello
         adding prettier @ ^2.0.5 (dev)
     writing updated package.json...
     running package install...
-Boltzmann at 0.1.1 with githubci, status, ping
+Boltzmann at 0.1.2 with githubci, ping, status
 ```
 
-A complete Boltzmann hello world is provided for you.
+You now have a complete hello world project in the `hello` directory, with commented source files to edit in place.
 
 ```shell
 hello|⇒ ls
@@ -84,22 +76,8 @@ module.exports = {
 
 To run: `./boltzmann.js`. And to view the response: `curl http://localhost:5000/hello/world`
 
-## Creating a boltzmann app
+The [context object](@/concepts/context.md) is where Boltzmann puts all data it derives from the initial request. It expects you to modify the context object in middleware: it is there to hold data you find useful through the request lifecycle. The raw node request and response objects are available on the context object if you need them, but we suggest you avoid modifying them directly.
 
-This repo includes a command-line tool, `boltzmann`, that generates a single javascript file with all of Boltzmann's implementation, and some scaffolding for a full Boltzmann app if it's not already present. The tool enables or disables specific Boltzmann features. The tool is safe to re-run, provided you are running it in a versioned git directory.
+The default scaffolded project also provides a commented `middleware.js` file to help you write your first middlewares. And finally, a linter is configured for you.
 
-To scaffold with redis and honeycomb:
-
-```sh
-npx boltzmann-cli --postgres --honeycomb todo-api
-```
-
-This creates a new project in `./todo-api` with postgres and Honeycomb integration enabled. If it finds existing code in `./todo-api`, it updates `boltzmann.js`.
-
-The scaffold currently assumes you're using node as your runtime and NPM as your package manager. It installs its dependencies for you, at the versions it needs. From this moment on, both boltzmann and its dependencies are under your management. Boltzmann is in your app repo as a *source file*, not as a dependency. You are free to make changes to the Boltzmann file, but be aware the scaffolding tool won't respect your changes if you run it again to update. You are also free to update or pin Boltzmann's dependencies.
-
-If you need to change Boltzmann's core behavior, you can either re-run the command-line tool to change features *or* write your own middleware. You'll be writing your own middleware for any reasonably complex project anyway!
-
-## The Boltzmann API
-
-If you prefer to look at working example code, we've provided examples in the [`./examples`](https://github.com/entropic-dev/boltzmann/tree/latest/examples) directory of this repo.
+To learn more about Boltzmann's fundamentals, check out the [concepts documentation](@/concepts/_index.md). If you need to deep-dive into details, see the [reference documentation](@/reference/_index.md).

--- a/docs/content/concepts/accepting-input.md
+++ b/docs/content/concepts/accepting-input.md
@@ -3,7 +3,10 @@ title="Accepting input"
 weight=6
 +++
 
-TODO: body parsing.
+Route parameters, query parameters, body parsing, and validating them all.
+
+<!-- more -->
+
 
 Boltzmann provides three validator decorators that rely on [the ajv schema validator](https://github.com/epoberezkin/ajv) for you to enforce a schema for your route parameters, query params, and body.  <!-- more -->
 The functions are:
@@ -29,3 +32,5 @@ async function identityDetail (/** @type {Context} */ context) { }
 ```
 
 The `boltzmann.decorators.params` function takes an ajv schema and generates a decorator that applies the schema to any route params supplied.
+
+TODO: body parsing.

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -9,46 +9,61 @@ The Boltzmann CLI creates and updates a node project for you, with a boltzmann.j
 
 <!-- more -->
 
-Boltzmann will manage its dependencies when a feature is flipped on or off, but will not make other changes to an existing package.json. You are free to update its dependencies as you see best.
+Running `npx boltzmann-cli --help` gives an overview of the command-line options. This document goes into more detail about them.
 
-## Features
+## Example usages
 
-The following features can be templated in:
+`npx boltzmann-cli web-server --redis --website`
 
-- `csrf`: Enable csrf protection middleware
-- `githubci`: Enable GitHub actions CI; defaults to on
-- `honeycomb`: Enable honeycomb
-- `jwt`: Enable jwt middleware; defaults to on
-- `ping`: Enable /monitor/ping liveness endpoint; defaults to on
-- `postgres`: Enable postgres
-- `redis`: Enable redis
-- `status`: Enable /monitor/status healthcheck endpoint; defaults to on
-- `templates`: Enable Nunjucks templates
+Scaffolds a project in the directory `./web-server`, with the redis, csrf, and templating features enabled.
 
-The GitHub CI workflow, ping, and status features are enabled by default. All other features are disabled by default.
+`npx boltzmann-cli api-server --githubci=off --honeycomb --jwt --postgres`
+
+Scaffolds a project in `./api-server` with Honeycomb tracing integration, jwt parsing, and postgres client middleware. Turns off the default GitHubCI workflow feature.
+
+## Feature-flipping
+
+Passing `--feature=[on,off]` turns the named feature on or off. You can also enable a feature by mentioning it: `--feature` is equivalent to `--feature=on`.
 
 You can rerun the boltzmann CLI in an existing project to update your copy of boltzmann or change which features you have enabled. The cli will respect the options you set earlier, and layer changes on top of this. To enable a feature, pass `--feature=on`.  For example, suppose you decide you need a redis client provided in middleware:
 
 ```shell
-hello|⇒ npx boltzmann-cli --redis=on .
-npx: installed 1 in 1.025s
-Scaffolding a Boltzmann service in /Users/ceejbot/code/hello/.
-    loaded settings from existing package.json
+code|⇒ npx boltzmann-cli hello --redis=on
+npx: installed 1 in 2.659s
+Scaffolding a Boltzmann service in /Users/cj/code/hello
+    initializing a new NPM package...
     writing boltzmann files...
     updating dependencies...
+        adding are-we-dev @ ^1.0.0
+        adding culture-ships @ ^1.0.0
+        adding find-my-way @ ^2.2.1
+        adding bole @ ^4.0.0
+        adding ajv @ ^6.12.2
+        adding dotenv @ ^8.2.0
+        adding accepts @ ^1.3.7
         adding handy-redis @ ^1.8.1 (redis activated)
         adding redis @ ^3.0.2 (redis activated)
+        adding cookie @ ^0.4.1
+        adding tap @ ^14.10.7 (dev)
+        adding @hapi/shot @ ^4.1.2 (dev)
+        adding bistre @ ^1.0.1 (dev)
+        adding eslint @ ^7.1.0 (dev)
+        adding @typescript-eslint/parser @ ^3.1.0 (dev)
+        adding @typescript-eslint/eslint-plugin @ ^3.1.0 (dev)
+        adding eslint-config-prettier @ ^6.11.0 (dev)
+        adding eslint-plugin-prettier @ ^3.1.3 (dev)
+        adding prettier @ ^2.0.5 (dev)
     writing updated package.json...
     running package install...
-Boltzmann at 0.1.1 with redis, githubci, status, ping
+Boltzmann at 0.1.2 with redis, githubci, status, ping
 ```
 
 Pass `--feature=off` to remove a feature you have previously enabled. For example, if you decide you don't need redis after all:
 
 ```shell
-hello|⇒ npx boltzmann-cli --redis=off .
-npx: installed 1 in 1.012s
-Scaffolding a Boltzmann service in /Users/ceejbot/code/hello/.
+code|⇒ npx boltzmann-cli hello --redis=off
+npx: installed 1 in 0.809s
+Scaffolding a Boltzmann service in /Users/cj/code/hello
     loaded settings from existing package.json
     writing boltzmann files...
     updating dependencies...
@@ -56,8 +71,37 @@ Scaffolding a Boltzmann service in /Users/ceejbot/code/hello/.
         removing redis (redis deactivated)
     writing updated package.json...
     running package install...
-Boltzmann at 0.1.1 with githubci, status, ping
+Boltzmann at 0.1.2 with githubci, status, ping
 ```
+
+Boltzmann will manage its dependencies when a feature is flipped on or off, but will not make other changes to an existing package.json. You are free to update its dependencies as you see best.
+
+## Command-line flags
+
+Boolean options:
+
+- `all`: Enables all features. Added in version 0.1.3.
+- `website`: Enable website feature set (templates, csrf). Added in version 0.1.3.
+- `selftest`: Turns on features for testing Boltzmann while developing it.
+- `docs`: Open the Boltzmann documentation in a web browser. Added in version 0.1.3.
+- `force`: Update a git-repo destination even if there are changes.
+- `silent`: Suppress all output except errors.
+- `verbose`: Log even more. Pass -v or -vv to increase verbosity.
+- `version`: Print version information.
+
+Feature-flipping options:
+
+- `csrf`: Enable csrf protection middleware.  Added in version 0.1.1.
+- `githubci`: Enable GitHub actions CI; defaults to on.
+- `honeycomb`: Enable [Honeycomb](https://www.honeycomb.io) tracing integration.
+- `jwt`: Enable jwt middleware; defaults to on. Added in version 0.1.1.
+- `ping`: Enable /monitor/ping liveness endpoint; defaults to on.
+- `postgres`: Enable postgres middleware.
+- `redis`: Enable redis middleware.
+- `status`: Enable /monitor/status healthcheck endpoint; defaults to on.
+- `templates`: Enable Nunjucks templates. Added in version 0.1.2.
+
+The GitHub CI workflow, ping, and status features are enabled by default. All other features are disabled by default.
 
 ## Full usage
 
@@ -78,6 +122,7 @@ USAGE:
 
 FLAGS:
         --all         Enable everything!
+        --docs        Open the Boltzmann documentation in a web browser.
         --force       Update a git-repo destination even if there are changes
     -h, --help        Prints help information
         --selftest    Build for a self-test.
@@ -99,4 +144,5 @@ OPTIONS:
 
 ARGS:
     <destination>    The path to the Boltzmann service [default: ]
+
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,13 +75,13 @@ pub struct Flags {
     #[structopt(short, long, parse(from_occurrences), help = "Pass -v or -vv to increase verbosity")]
     verbose: u64, // huge but this is what our logger wants
 
-    #[structopt(long, short, help = "Suppress all output except errors.")]
+    #[structopt(long, short, help = "Suppress all output except errors")]
     silent: bool,
 
-    #[structopt(long, help = "Build for a self-test.")]
+    #[structopt(long, help = "Build for a self-test")]
     selftest: bool, // turn on the oven in self-cleaning mode.
 
-    #[structopt(long, help = "Open the Boltzmann documentation in a web browser.")]
+    #[structopt(long, help = "Open the Boltzmann documentation in a web browser")]
     docs: bool,
 
     #[structopt(parse(from_os_str), help = "The path to the Boltzmann service", default_value = "")]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -121,6 +121,9 @@ impl fmt::Display for Settings {
         if self.templates.unwrap_or(false) {
             features.push("templates");
         }
+        // In case we have some bad people who don't alphabetize the above.
+        features.sort_unstable();
+
         // Oddball is last.
         if self.selftest.unwrap_or(false) {
             features.push("selftest");

--- a/templates/handlers.js
+++ b/templates/handlers.js
@@ -1,19 +1,18 @@
 const { Context } = require('./boltzmann.js') // optionally pull in typescript definition
 
 greeting.route = 'GET /hello/:name'
-// {% if templates %}
+{% if templates %}
 async function greeting(/** @type {Context} */ context) {
   return {
     [Symbol.for('template')]: 'index.html',
     name: context.params.name,
   }
 }
-// {% else %}
+{% else %}
 async function greeting(/** @type {Context} */ context) {
   return `hello ${context.params.name}`
 }
-// {% endif %}
-
+{% endif %}
 module.exports = {
   greeting,
 }

--- a/templates/middleware.js
+++ b/templates/middleware.js
@@ -22,8 +22,8 @@ function setupMiddlewareFunc(/* your config */) {
 
 // Here's a more compactly-defined middleware.
 function routeMiddlewareFunc(/* your config */) {
-  return next => {
-    return context => {
+  return (next) => {
+    return (context) => {
       return next(context)
     }
   }
@@ -51,7 +51,7 @@ module.exports = {
     [boltzmann.middleware.template, {
       // filters: {}, // add custom template filters
       // tags: {}     // extend nunjucks with custom tags
-    }]
+    }],
     {%- endif %}
-  ]
+  ],
 }


### PR DESCRIPTION
Improved the CLI option docs.

Scratched an itch I've had for a while by making the docs landing page not a rehash of the readme. It's no longer a rehash of the repo readme because a) the repo readme is shorter (it's the manifesto) and the landing page goes into more detail and does some linking to useful doc starting points.

Bonus: the default scaffolded project almost passes lint. There's one bug in that the middleware template pulls in boltzmann, but the default option set doesn't enable anything that uses the variable.


