### PR TITLE
Add ESM support for Node 14.

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -11,6 +11,14 @@ function run_selftest() {
   cd ..
 }
 
+function run_esm_selftest() {
+  rm -rf tmp
+  cargo run -- --selftest --esm --force  --silent tmp
+  cd tmp
+  node test.js
+  cd ..
+}
+
 function run_startup() {
   rm -rf tmp
   cargo run -- tmp --force --silent

--- a/src/dependencies.ron
+++ b/src/dependencies.ron
@@ -12,6 +12,15 @@
     preconditions: None
   ),
   DependencySpec(
+    name: "es-main",
+    version: "^1.0.2",
+    kind: Normal,
+    preconditions: Some(When(
+      feature: Some("esm"),
+      if_not_present: []
+    ))
+  ),
+  DependencySpec(
     name: "nunjucks",
     version: "^3.2.1",
     kind: Normal,
@@ -132,7 +141,7 @@
   ),
   DependencySpec(
     name: "@hapi/shot",
-    version: "^4.1.2",
+    version: "^5.0.4",
     kind: Development,
     preconditions: None
   ),

--- a/src/dirspec.ron
+++ b/src/dirspec.ron
@@ -56,8 +56,8 @@ Dir(DirSpec(
 
     // jumper module for selftest, to trick tap into
     // reporting test coverage output for boltzmann.js
-    ("test.js", 0o644, File(FileSpec(
-      contents: "require('./boltzmann')"
+    ("test.js", 0o644, Template(TemplateSpec(
+      template_name: "selftest.js",
     )), Some(When(
       feature: Some("selftest"),
       if_not_present: []

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,9 @@ pub struct Flags {
     #[structopt(long, help = "Enable Nunjucks templates")]
     templates: Option<Option<Flipper>>,
 
+    #[structopt(long, help = "Scaffold project using ES Modules")]
+    esm: Option<Option<Flipper>>,
+
     #[structopt(long, help = "Enable csrf protection middleware")]
     csrf: Option<Option<Flipper>>,
 
@@ -130,6 +133,9 @@ struct PackageJson {
 
     #[serde(rename = "devDependencies")]
     dev_dependencies: Option<BTreeMap<String, String>>,
+
+    #[serde(rename = "type")]
+    module_type: Option<String>,
 
     scripts: Option<RunScripts>,
     boltzmann: Option<Settings>,
@@ -364,6 +370,12 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error + 'static>> {
         } else if !has_dep_currently {
             info!("        adding {} @ {} {}", candidate.name.bold().magenta(), candidate.version, candidate.kind);
             target.insert(candidate.name, candidate.version);
+        }
+    }
+
+    if let Some(esm) = updated_settings.esm {
+        if esm {
+            package_json.module_type = Some("module".to_string());
         }
     }
 

--- a/templates/handlers.js
+++ b/templates/handlers.js
@@ -1,3 +1,11 @@
+// {% if esm %}
+import { Context } from './boltzmann.js' // optionally pull in typescript definition
+
+greeting.route = 'GET /hello/:name'
+export async function greeting(/** @type {Context} */ context) {
+  return `hello ${context.params.name}`
+}
+// {% else %}
 const { Context } = require('./boltzmann.js') // optionally pull in typescript definition
 
 greeting.route = 'GET /hello/:name'
@@ -17,3 +25,4 @@ async function greeting(/** @type {Context} */ context) {
 module.exports = {
   greeting,
 }
+// {% endif %}

--- a/templates/middleware.js
+++ b/templates/middleware.js
@@ -1,10 +1,14 @@
 'use strict'
 
+// {% if esm %}
+import { middleware } from './boltzmann.js'
+// {% else %}
 const boltzmann = require('./boltzmann')
+// {% endif %}
 
 // All Boltzmann middleware looks like this.
 // Middleware can be attached to either the app or individual routes.
-function setupMiddlewareFunc(/* your config */) {
+{% if esm %}export{% endif %} function setupMiddlewareFunc(/* your config */) {
   // startup configuration goes here
   return function createMiddlewareFunc(next) {
     return async function inner(context) {
@@ -21,7 +25,7 @@ function setupMiddlewareFunc(/* your config */) {
 }
 
 // Here's a more compactly-defined middleware.
-function routeMiddlewareFunc(/* your config */) {
+{% if esm %}export{% endif %} function routeMiddlewareFunc(/* your config */) {
   return next => {
     return context => {
       return next(context)
@@ -29,6 +33,28 @@ function routeMiddlewareFunc(/* your config */) {
   }
 }
 
+// {% if esm %}
+// This export is special: it instructs Boltzmann to attach
+// middlewares to the app in this order.
+// This is also where you can configure built-in middleware.
+export const APP_MIDDLEWARE = [
+  setupMiddlewareFunc,
+  {%- if csrf %}
+  [boltzmann.middleware.applyCSRF, {
+    // cookieSecret: process.env.COOKIE_SECRET,
+    // csrfCookie: '_csrf',
+    // param: '_csrf',
+    // header: 'csrf-token'
+  }],
+  {%- endif %}
+  {%- if templates %}
+  [middleware.template, {
+    // filters: {}, // add custom template filters
+    // tags: {}     // extend nunjucks with custom tags
+  }]
+  {%- endif %}
+]
+// {% else %}
 module.exports = {
   // You can export middleware for testing or for
   // attaching to routes.
@@ -55,3 +81,4 @@ module.exports = {
     {%- endif %}
   ]
 }
+// {% endif %}

--- a/templates/selftest.js
+++ b/templates/selftest.js
@@ -1,0 +1,5 @@
+{% if esm %}
+import "./boltzmann.js"
+{% else %}
+require('./boltzmann')
+{% endif %}


### PR DESCRIPTION
ESM is a special flag. It is not implied by "--all" or "--selftest"
and is tested separately.

Turning the flag on puts the application in "module mode" by setting
the "type" flag in `package.json`. `boltzmann.js` then expects to load
all application files (middleware, handlers, etc.) via `import()`.

The upside: it works! Import syntax makes handlers definition much nicer
by baking the export status into the definition of the handler function.
This also puts all files into strict mode by default, which is good for
usabiliy and performance.

The downside is that it forks exports and imports in all of our generated
files. I think, medium-to-long-term, it's worthwhile: ESM is the future of JS,
t and Node 14 forces the issue. Ultimately, we should default to ESM. HOWEVER,
this complicates hot-reloading slightly: it means we end up having to build
it twice (or have one mode that supports it, and one that doesn't.)

NB: stackman support is broken for now – I've opened [a PR](https://github.com/watson/stackman/pull/15) that fixes the ESM-induced regression.