### PR TITLE
Fix issue #39: bad middleware config should fail fast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "boltzmann"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "atty",

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -55,7 +55,7 @@ Boltzmann also relies on a little bit of convention to simplify configuration.
 For instance, it assumes that all route handlers are exported from
 `handlers.js` or a `handlers/` directory in the same level of the project. The
 same is true for middleware: you can move to exports from a `middleware/`
-directory if you outgrow the initial `middlware.js` file.
+directory if you outgrow the initial `middleware.js` file.
 
 ## Hello world
 

--- a/src/dependencies.ron
+++ b/src/dependencies.ron
@@ -43,7 +43,7 @@
   ),
   DependencySpec(
     name: "find-my-way",
-    version: "^2.2.1",
+    version: "^3.0.4",
     kind: Normal,
     preconditions: None
   ),
@@ -97,7 +97,7 @@
   ),
   DependencySpec(
     name: "pg",
-    version: "^7.18.2",
+    version: "^8.3.3",
     kind: Normal,
     preconditions: Some(When(  feature: Some("postgres"),if_not_present: [] ))
   ),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -89,7 +89,7 @@ impl Settings {
             ping: cast(&flags.ping, &self.ping, flags.all || flags.website),
             postgres: cast(&flags.postgres, &self.postgres, flags.all),
             redis: cast(&flags.redis, &self.redis, flags.all),
-            esm: if is_esm { Some(true) } else { None }, 
+            esm: if is_esm { Some(true) } else { None },
 
             status: cast(&flags.status, &self.status, flags.all || flags.website),
             templates: cast(&flags.templates, &self.templates, flags.all || flags.website),

--- a/templates/boltzmann.js
+++ b/templates/boltzmann.js
@@ -553,12 +553,12 @@ function template ({
 } = {}) {
   const nunjucks = require('nunjucks')
   const path = require('path')
-  if (!Array.isArray(paths)) {
-    if (typeof paths == 'string') {
-      paths = [paths]
-    } else {
-      throw new TypeError('the paths option for template() must be an array of path strings')
-    }
+  paths = [].concat(paths)
+  try {
+    const assert = require('assert')
+    paths.forEach(xs => assert(typeof xs == 'string'))
+  } catch (_c) {
+    throw new TypeError('The `paths` option for template() must be an array of path strings')
   }
 
   paths = paths.slice().map(
@@ -1276,18 +1276,19 @@ function authenticateJWT ({
   algorithms=['RS256'],
   storeAs = 'user'
 } = {}) {
-  if (!Array.isArray(algorithms)) {
-    if (typeof algorithms == 'string') {
-      algorithms = [algorithms]
-    } else {
-      throw new TypeError('The `algorithms` config option for JWTs must be an array of strings')
-    }
+  algorithms = [].concat(algorithms)
+  try {
+    const assert = require('assert')
+    algorithms.forEach(xs => assert(typeof xs == 'string'))
+  } catch (_c) {
+    throw new TypeError('The `algorithms` config option for JWTs must be an array of strings')
   }
   if (!publicKey) {
     throw new Error(
       `To authenticate JWTs you must pass the path to a public key file in either
 the environment variable "AUTHENTICATION_KEY" or the publicKey config field
-      `.trim().split('\n').join(' '))
+https://www.boltzmann.dev/en/docs/{{ version }}/reference/middleware/#authenticatejwt
+`.trim().split('\n').join(' '))
   }
   const verifyJWT = require('jsonwebtoken').verify
 
@@ -1299,6 +1300,7 @@ the environment variable "AUTHENTICATION_KEY" or the publicKey config field
           boltzmann authenticateJWT middleware cannot read public key at "${publicKey}".
           Is the AUTHENTICATION_KEY environment variable set correctly?
           Is the file readable?
+          https://www.boltzmann.dev/en/docs/{{ version }}/reference/middleware/#authenticatejwt
         `.trim().split('\n').join(' '))
         throw err
       })

--- a/templates/middleware.js
+++ b/templates/middleware.js
@@ -63,25 +63,24 @@ module.exports = {
     // This export is special: it instructs Boltzmann to attach middlewares to the app in this
     // order. This is also where you can configure built-in middleware.
     setupMiddlewareFunc,
-    // Must be one of DENY or SAMEORIGIN; uncomment to enable
-    // [boltzmann.middleware.applyXFO, 'SAMEORIGIN'],
+    // [boltzmann.middleware.applyXFO, 'SAMEORIGIN'], // Must be one of DENY or SAMEORIGIN; uncomment to enable
     {%- if jwt %}
     /* Provide a path to a file containing your public key & uncomment to enable
     [boltzmann.middleware.authenticateJWT, {
-      // scheme: 'Bearer',
-      // publicKey: process.env.AUTHENTICATION_KEY, // path to a file containing a key
-      // algorithms: ['RS256'],
-      // storeAs: 'user'
+      // scheme: 'Bearer',      // Default; uncomment & edit to use another value.
+      // publicKey: process.env.AUTHENTICATION_KEY, // Set env var OR this key to path to a file containing a key
+      // algorithms: ['RS256'], // Default; uncomment & edit to use another value.
+      // storeAs: 'user'        // Default; uncomment & edit to use another value.
     }],
     */
     {%- endif %}
     {%- if csrf %}
-    /* Provide a cookie secret & uncomment to enable
+    /* Provide a cookie secret & uncomment to enable.
     [boltzmann.middleware.applyCSRF, {
-      // cookieSecret: process.env.COOKIE_SECRET,
-      // csrfCookie: '_csrf',
-      // param: '_csrf',
-      // header: 'csrf-token'
+      // cookieSecret: process.env.COOKIE_SECRET, //  Set the env var to change.
+      // csrfCookie: '_csrf',  // Default; uncomment & edit to use another value.
+      // param: '_csrf',       // Default; uncomment & edit to use another value.
+      // header: 'csrf-token'  // Default; uncomment & edit to use another value.
     }],
     */
     {%- endif %}

--- a/templates/middleware.js
+++ b/templates/middleware.js
@@ -56,25 +56,38 @@ export const APP_MIDDLEWARE = [
 ]
 // {% else %}
 module.exports = {
-  // You can export middleware for testing or for
-  // attaching to routes.
+  // You can export middleware for testing or for attaching to routes.
   routeMiddlewareFunc,
   setupMiddlewareFunc,
   APP_MIDDLEWARE: [
-    // This export is special: it instructs Boltzmann to attach
-    // middlewares to the app in this order.
-    // This is also where you can configure built-in middleware.
+    // This export is special: it instructs Boltzmann to attach middlewares to the app in this
+    // order. This is also where you can configure built-in middleware.
     setupMiddlewareFunc,
+    // Must be one of DENY or SAMEORIGIN; uncomment to enable
+    // [boltzmann.middleware.applyXFO, 'SAMEORIGIN'],
+    {%- if jwt %}
+    /* Provide a path to a file containing your public key & uncomment to enable
+    [boltzmann.middleware.authenticateJWT, {
+      // scheme: 'Bearer',
+      // publicKey: process.env.AUTHENTICATION_KEY, // path to a file containing a key
+      // algorithms: ['RS256'],
+      // storeAs: 'user'
+    }],
+    */
+    {%- endif %}
     {%- if csrf %}
+    /* Provide a cookie secret & uncomment to enable
     [boltzmann.middleware.applyCSRF, {
       // cookieSecret: process.env.COOKIE_SECRET,
       // csrfCookie: '_csrf',
       // param: '_csrf',
       // header: 'csrf-token'
     }],
+    */
     {%- endif %}
     {%- if templates %}
     [boltzmann.middleware.template, {
+      // paths: ['templates'], // change template file locations
       // filters: {}, // add custom template filters
       // tags: {}     // extend nunjucks with custom tags
     }],

--- a/templates/middleware.js
+++ b/templates/middleware.js
@@ -63,7 +63,6 @@ module.exports = {
     // This export is special: it instructs Boltzmann to attach middlewares to the app in this
     // order. This is also where you can configure built-in middleware.
     setupMiddlewareFunc,
-    // [boltzmann.middleware.applyXFO, 'SAMEORIGIN'], // Must be one of DENY or SAMEORIGIN; uncomment to enable
     {%- if jwt %}
     /* Provide a path to a file containing your public key & uncomment to enable
     [boltzmann.middleware.authenticateJWT, {
@@ -85,6 +84,7 @@ module.exports = {
     */
     {%- endif %}
     {%- if templates %}
+    [boltzmann.middleware.applyXFO, 'SAMEORIGIN'], // Must be one of DENY or SAMEORIGIN
     [boltzmann.middleware.template, {
       // paths: ['templates'], // change template file locations
       // filters: {}, // add custom template filters


### PR DESCRIPTION
applyXFO() now fails fast. Added a test.

template() now fails informatively if `paths` cannot be an
array of strings instead of failing uniformatively. Added a test.

authenticateJWT() now wants an array of strings for its algorithms
config. It doesn't attempt to validate the algorithm choices.
It also requires that you set something in AUTHENTICATION_KEY so it
can fail fast if you've forgotten to. This required some test updates.

Extended the scaffold to include more middleware config examples.
The scaffolded project runs out of the box, though it does not yet
quite pass lint out of the box. (Apparently my favorite misspelling
this week is "middlware".)