### PR TITLE
feat: add context.traceURL

### DIFF
--- a/docs/content/reference/02-handlers.md
+++ b/docs/content/reference/02-handlers.md
@@ -353,6 +353,29 @@ async function logout(context) {
 }
 ```
 
+### `traceURL`
+
+_Added in 0.1.4._ **Requires the [`--honeycomb`] feature.**
+
+A URL `string` suitable for navigating to the [Honeycomb] user interface and displaying the trace
+from the current request.
+
+**Example use:**
+
+```javascript
+example.route = 'GET /'
+async function example(context) {
+  await someComplicatedBusinessLogic()
+
+  console.log(
+    'Click on the following URL for details & timings on this request!'
+  )
+
+  console.log(context.traceURL) // https://ui.honeycomb.io/trace?some=query&params
+  return { some: 'complicated result' }
+}
+```
+
 ### `url`
 
 _Added in 0.0.0._
@@ -724,9 +747,11 @@ async function example2(context) {
 ["persisting data" chapter]: #TKTKTK
 [`URLSearchParams`]: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
 [`--redis`]: @/reference/01-cli.md#redis
+[`--honeycomb`]: @/reference/01-cli.md#honeycomb
 [`handy-redis`]: https://github.com/mmkal/handy-redis#handy-redis
 [`request.socket.remoteAddress`]: https://nodejs.org/api/net.html#net_socket_remoteaddress
 [`Date.now()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now
 [`URL`]: https://developer.mozilla.org/en-US/docs/Web/API/URL_API
 [chapter on "handlers"]: @/concepts/01-handlers.md#responses
 [symbols]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol
+[`Honeycomb`]: https://honeycomb.io

--- a/templates/boltzmann.js
+++ b/templates/boltzmann.js
@@ -221,6 +221,15 @@ let ajvStrict = null
     return this.request.headers
   }
 
+  // {% if honeycomb %}
+  get traceURL () {
+    const url = new URL(`https://ui.honeycomb.io/${process.env.HONEYCOMBIO_TEAM}/datasets/${process.env.HONEYCOMBIO_DATASET}/trace`)
+    url.searchParams.set('trace_id', this._honeycombTrace.payload['trace.trace_id'])
+    url.searchParams.set('trace_start_ts', Math.floor(this._honeycombTrace.startTime/1000 - 1))
+    return String(url)
+  }
+  // {% endif %}
+
   get url() {
     if (this._parsedUrl) {
       return this._parsedUrl
@@ -747,7 +756,7 @@ function template ({
               <td class="tr white-80 v-top pr2">Honeycomb Trace</td>
               <td>
                 {% if context._honeycombTrace %}
-                  <a class="link underline washed-blue dim" target="_blank" rel="noreferrer noopener" href="http://ui.honeycomb.io/${process.env.HONEYCOMBIO_TEAM}/datasets/${process.env.HONEYCOMBIO_DATASET}/trace?trace_id={{ context._honeycombTrace.payload['trace.trace_id'] }}&trace_start_ts={{ (context._honeycombTrace.startTime/1000 - 1)|round }}">
+                  <a class="link underline washed-blue dim" target="_blank" rel="noreferrer noopener" href="{{ context.traceURL }}">
                     Available
                   </a>
                 {% else %}


### PR DESCRIPTION
This adds a `.traceURL` property to `Context`, suitable for navigating to the Honeycomb UI for a given request. (I used this last night to debug a perf problem, & it occurred to me that it'd be handy to have it available via context instead of having to construct it manually in a handler for logging.)