### PR TITLE
Keep dep specs locked to Boltzmann's definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "boltzmann"
-version = "0.1.4"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["C J Silverio <ceejceej@gmail.com>", "Chris Dickinson <chris@neversaw.us>"]
 edition = "2018"
 name = "boltzmann"
-version = "0.1.4"
+version = "0.1.6"
 
 [dependencies]
 anyhow = "1.0.32"

--- a/src/main.rs
+++ b/src/main.rs
@@ -379,6 +379,11 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error + 'static>> {
         } else if !has_dep_currently {
             info!("        adding {} @ {} {}", candidate.name.bold().magenta(), candidate.version, candidate.kind);
             target.insert(candidate.name, candidate.version);
+        } else if let Some(current_value) = target.get(&candidate.name[..]) {
+            if current_value.as_str() != candidate.version.as_str() {
+                info!("        updating {} @ {} {}", candidate.name.bold().magenta(), candidate.version, candidate.kind);
+                target.insert(candidate.name, candidate.version);
+            }
         }
     }
 


### PR DESCRIPTION
While bringing auth-2020 up-to-date, I noticed that running boltzmann upgrades would not update deps that were not required by a feature. This fixes that bug!