### PR TITLE
fix: add cookieOptions to session middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "boltzmann"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["C J Silverio <ceejceej@gmail.com>", "Chris Dickinson <chris@neversaw.us>"]
 edition = "2018"
 name = "boltzmann"
-version = "0.1.6"
+version = "0.1.7"
 
 [dependencies]
 anyhow = "1.0.32"

--- a/docs/content/reference/03-middleware.md
+++ b/docs/content/reference/03-middleware.md
@@ -49,6 +49,7 @@ _Added in 0.1.4_.
 - `iron`: Extra options for [`@hapi/iron`], which is used to seal the client session id for transport in
   a cookie.
 - `expirySeconds`: The number of seconds until the cookie expires. Defaults to one year.
+- `cookieOptions`: An object containing options passed to the [`cookie`] package when serializing a session id.
 
 You can import session middleware with `require('./boltzmann').middleware.session`. The session middleware
 provides [HTTP session support] using sealed http-only [cookies]. You can read more about Boltzmann's session
@@ -92,6 +93,15 @@ module.exports = {
     }]
   ]
 }
+
+// A configuration that sets "same-site" to "lax", suitable for sites that require cookies
+// to be sent when redirecting from an external site. E.g., sites that use OAuth-style login
+// flows.
+module.exports = {
+  APP_MIDDLEWARE: [
+    [middleware.session, { cookieOptions: { sameSite: 'lax' } }],
+  ]
+};
 ```
 
 [`--redis`]: @/reference/01-cli.md#redis
@@ -99,6 +109,7 @@ module.exports = {
 [HTTP session support]: https://en.wikipedia.org/wiki/Session_(computer_science)#HTTP_session_token
 [cookies]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies
 ["storage" chapter]: #TKTKTK
+[`cookie`]: https://www.npmjs.com/package/cookie#options-1
 
 ---
 

--- a/templates/boltzmann.js
+++ b/templates/boltzmann.js
@@ -1669,6 +1669,7 @@ function session ({
   async (context, id, session) => IN_MEMORY.set(id, JSON.stringify(session)),
 // {% endif %}
   iron = {},
+  cookieOptions = {},
   expirySeconds = 60 * 60 * 24 * 365
 } = {}) {
   let _iron = null
@@ -1754,7 +1755,8 @@ function session ({
           httpOnly: true,
           sameSite: true,
           maxAge: expirySeconds,
-          ...(expirySeconds ? {} : {expires: new Date(Date.now() + 1000 * expirySeconds)})
+          ...(expirySeconds ? {} : {expires: new Date(Date.now() + 1000 * expirySeconds)}),
+          ...cookieOptions
         })
       }
 

--- a/templates/middleware.js
+++ b/templates/middleware.js
@@ -40,7 +40,7 @@ const boltzmann = require('./boltzmann')
 export const APP_MIDDLEWARE = [
   setupMiddlewareFunc,
   {%- if csrf %}
-  [boltzmann.middleware.applyCSRF, {
+  [middleware.applyCSRF, {
     // cookieSecret: process.env.COOKIE_SECRET,
     // csrfCookie: '_csrf',
     // param: '_csrf',


### PR DESCRIPTION
`sameSite: strict` – the default – means that cookies will not be sent on a request redirected from an external site (including oauth providers.)