### PR TITLE
inject versions into docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,8 @@ jobs:
             echo "prerelease; skipping latest"
           else
             # TODO: I bet you could do this with a redirect object in S3.
-            aws s3 cp --recursive . s3://www.boltzmann.dev/en/docs/latest --acl public-read
+            aws s3 sync . s3://www.boltzmann.dev/en/docs/latest --acl public-read
           fi
-
-          cd ..
 
           # rewrite all the old docs with the new version tags.
           for tag in $all_tags; do
@@ -56,18 +54,14 @@ jobs:
               continue
             fi
 
-            rm -rf docs
-            mkdir docs
-            cd docs
-            aws s3 cp --recursive s3://www.boltzmann.dev/en/docs/${tag} .
+            aws s3 sync s3://www.boltzmann.dev/en/docs/${tag} .
 
             for file in $(find . -type f -name '*.html'); do
               contents=$(cat $file | hq 'nav#versions' @<(get_active_docs ${tag}))
               echo "$contents" > $file
             done
 
-            aws s3 cp --recursive . s3://www.boltzmann.dev/en/docs/${tag} --acl public-read
-            cd ..
+            aws s3 sync . s3://www.boltzmann.dev/en/docs/${tag} --acl public-read
           done
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,19 +7,68 @@ jobs:
     name: publish docs
     runs-on: ubuntu-latest
     steps:
+      - name: download hq
+        run: |
+          curl -sL https://github.com/chrisdickinson/hq/releases/download/v1.0.0/hq_x64_linux.tar.gz | tar xfz -
       - name: download docs
         run: |
           tag=${{ github.ref }}
+          current_tag=${tag/refs\/tags\//}
           download_url=$(
-            curl -sL https://api.github.com/repos/entropic-dev/boltzmann/releases/tags/${tag/refs\/tags\//} | \
+            curl -sL https://api.github.com/repos/entropic-dev/boltzmann/releases/tags/${current_tag} | \
               jq -r '.assets[] | .browser_download_url' | \
               grep 'docs'
           )
+
+          all_tags=$(curl -sL https://api.github.com/repos/entropic-dev/boltzmann/releases | jq -r '.[] | .tag_name')
+
+          function get_active_docs() {
+            local active=$1
+            echo "<ul>"
+            for tag in $all_tags; do
+              echo "<li>"
+              echo '<a class="'$(if [[ $tag == $active ]]; then echo "active"; fi; echo " "; if [[ $tag =~ .+-.+ ]]; then echo "prerelease"; fi;)'" href="https://www.boltzmann.dev/en/docs/'$tag'">' $tag '</a>'
+              echo "</li>"
+            done
+            echo "</ul>"
+          }
+
           mkdir docs
           curl -sL $download_url | tar zx -C docs
           cd docs
-          aws s3 cp --recursive . s3://www.boltzmann.dev/en/docs/${tag/refs\/tags\//} --acl public-read
+          for file in $(find . -type f -name '*.html'); do
+            contents=$(cat $file | hq 'nav#versions' @<(get_active_docs ${current_tag}))
+            echo "$contents" > $file
+          done
+          aws s3 cp --recursive . s3://www.boltzmann.dev/en/docs/${current_tag} --acl public-read
+          if [[ $current_tag =~ .+-.+ ]]; then
+            echo "prerelease; skipping latest"
+          else
+            # TODO: I bet you could do this with a redirect object in S3.
+            aws s3 cp --recursive . s3://www.boltzmann.dev/en/docs/latest --acl public-read
+          fi
+
           cd ..
+
+          # rewrite all the old docs with the new version tags.
+          for tag in $all_tags; do
+            if [[ "$tag" == "$current_tag" ]]; then
+              continue
+            fi
+
+            rm -rf docs
+            mkdir docs
+            cd docs
+            aws s3 cp --recursive s3://www.boltzmann.dev/en/docs/${tag} .
+
+            for file in $(find . -type f -name '*.html'); do
+              contents=$(cat $file | hq 'nav#versions' @<(get_active_docs ${tag}))
+              echo "$contents" > $file
+            done
+
+            aws s3 cp --recursive . s3://www.boltzmann.dev/en/docs/${tag} --acl public-read
+            cd ..
+          done
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/TODO
+++ b/TODO
@@ -1,5 +1,15 @@
 ## TODO
 
+### 2020-12-04
+
+- [ ] documentation version picker
+  - ideally fully static:
+    - [ ] download all versions of the docs
+    - [ ] find all version selectors
+    - [ ] update the selector with the new set of versions
+    - [ ] create a "latest" tag
+    - [ ] DONE
+
 ### 2020-06-05
 
 - [ ] investigate static site generators

--- a/docs/themes/boltzie/templates/index.html
+++ b/docs/themes/boltzie/templates/index.html
@@ -31,6 +31,10 @@
       {% endblock nav %}
       </nav>
 
+      <nav id="versions">
+        <!-- these contents will be replaced by the github release workflow. -->
+      </nav>
+
       <main>
       {% block content %}
 


### PR DESCRIPTION
Well, it involved writing a tool to rewrite HTML. [_cough_](https://github.com/chrisdickinson/hq/blob/main/src/main.rs) – really it was just slightly modifying the source of [lol-html](https://lib.rs/lol-html).

This is a WIP PR since I haven't actually tried it in anger.

This PR modifies the docs release action: in addition to uploading the docs to the current version number, it will also upload them to the special url `/en/docs/latest` _if_ the tag does not contain a `-`. (This lets us skip `v0.2.0-alpha1`.) Making sure that the `latest` URL reflects the _actual_ latest tag from a semver standpoint is work left to be done later, when we need it.

The action now rewrites the generated HTML of the current version by replacing `nav#versions` with a list of links to all available versions. Once the current version is uploaded to S3, all other versions are downloaded, edited, and re-uploaded. This is, as you know, a solution with a half-life; but we'll see if we get to the point that we need to optimize this.