### PR TITLE
fix: make sure the docs command calls correctly

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -148,7 +148,7 @@ impl RunScripts {
     }
 
     fn docs_string() -> String {
-        "npx boltzmann-cli docs".to_string()
+        "npx boltzmann-cli --docs".to_string()
     }
 }
 


### PR DESCRIPTION
The scaffolded option was creating a boltzmann project called "docs". This replaces with the flag.