### PR TITLE
feat: use `textwrap` to wrap a potentially long output line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,7 @@ dependencies = [
  "structopt",
  "subprocess",
  "tera",
+ "textwrap 0.13.1",
 ]
 
 [[package]]
@@ -160,7 +161,7 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
 ]
@@ -652,6 +653,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smawk"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1bc737c97d093feb72e67f4926d9b22d717ce8580cd25f0ce86d74e859c466d"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,11 +743,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd2d183bd3fac5f5fe38ddbeb4dc9aec4a39a9d7d59e7491d900302da01cbe1"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aca9e798437265144ddacce09343df0b3413a0aef54b1e212e640e472118b80"
+dependencies = [
+ "smawk",
+ "terminal_size",
  "unicode-width",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0.57"
 structopt = "0.3.17"
 subprocess = "*"
 tera = "1.5.0"
+textwrap = { version = "0.13", features = ["terminal_size"] }
 
 [dependencies.serde]
 features = ["derive"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -470,7 +470,16 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error + 'static>> {
 
     match exit_status {
         ExitStatus::Exited(0) => {
-            warn!("Boltzmann at {} with {}", option_env!("CARGO_PKG_VERSION").unwrap_or_else(|| "0.0.0").bold(), updated_settings);
+            let report = format!( "Boltzmann @ {} with {}", option_env!("CARGO_PKG_VERSION").unwrap_or_else(|| "0.0.0").bold(), updated_settings);
+            warn!(
+                "{}",
+                textwrap::fill(
+                    &report,
+                    textwrap::Options::with_termwidth()
+                        .initial_indent("")
+                        .subsequent_indent("    ")
+                )
+            );
             Ok(())
         },
         _ => Err(anyhow!("npm install exited with non-zero status").into())


### PR DESCRIPTION
This also indents subsequent lines of the output.