### PR TITLE
feat: run-script messaging is now more compact

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "boltzmann"
-version = "0.2.0"
+version = "0.3.0-rc.1"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["C J Silverio <ceejceej@gmail.com>", "Chris Dickinson <chris@neversaw.us>"]
 edition = "2018"
 name = "boltzmann"
-version = "0.2.0"
+version = "0.3.0-rc.1"
 
 [dependencies]
 anyhow = "1.0.32"

--- a/bin/release
+++ b/bin/release
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 print_help() {
   cat >&2 <<EOF
 USAGE: bin/release [level]

--- a/src/dependencies.ron
+++ b/src/dependencies.ron
@@ -46,15 +46,7 @@
     version: "^2.4.6",
     kind: Normal,
     preconditions: Some(When(
-      all_of: ["esbuild"],
-    ))
-  ),
-  DependencySpec(
-    name: "mime",
-    version: "^2.4.6",
-    kind: Normal,
-    preconditions: Some(When(
-      all_of: ["staticfiles"],
+      any_of: ["esbuild", "staticfiles"],
     ))
   ),
   DependencySpec(

--- a/src/dependencies.ron
+++ b/src/dependencies.ron
@@ -12,6 +12,14 @@
     preconditions: None
   ),
   DependencySpec(
+    name: "oblique-strategies",
+    version: "*",
+    kind: Normal,
+    preconditions: Some(When(
+      none_of: [ "typescript" ]
+    ))
+  ),
+  DependencySpec(
     name: "@hapi/iron",
     version: "^6.0.0",
     kind: Normal,

--- a/src/dirspec.ron
+++ b/src/dirspec.ron
@@ -92,13 +92,29 @@ Dir(DirSpec(
     (".eslintrc.js", 0o644, Template(TemplateSpec(
       template_name: "eslintrc.js"
     )), Some(When(
-      if_not_present: [".eslintrc.js", ".eslintrc"]
+      if_not_present: [".eslintrc.js", ".eslintrc"],
+      none_of: ["esm"]
+    ))),
+
+    (".eslintrc.cjs", 0o644, Template(TemplateSpec(
+      template_name: "eslintrc.js"
+    )), Some(When(
+      if_not_present: [".eslintrc.js", ".eslintrc"],
+      all_of: ["esm"],
     ))),
 
     (".prettierrc.js", 0o644, Template(TemplateSpec(
       template_name: "prettierrc.js"
     )), Some(When(
-      if_not_present: [".prettierrc.js", ".prettierrc" ]
+      if_not_present: [".prettierrc.js", ".prettierrc" ],
+      none_of: ["esm"]
+    ))),
+
+    (".prettierrc.cjs", 0o644, Template(TemplateSpec(
+      template_name: "prettierrc.js"
+    )), Some(When(
+      if_not_present: [".prettierrc.cjs", ".prettierrc" ],
+      all_of: ["esm"]
     ))),
 
     (".github", 0o755, Dir(DirSpec(

--- a/src/render.rs
+++ b/src/render.rs
@@ -105,6 +105,17 @@ fn render_dir(
     let mut created = HashSet::new();
     'next: for (basename, mode, node, when) in spec.children {
         if let Some(preconditions) = when {
+            // first, skip what we skip if they already exist...
+            let mut cloned_cwd = cwd.clone();
+            for dir in preconditions.if_not_present {
+                // if any of these directories exist, bail
+                cloned_cwd.push(dir);
+                if cloned_cwd.as_path().exists() {
+                    continue 'next;
+                }
+                cloned_cwd.pop();
+            }
+
             for exclude in preconditions.none_of {
                 let has_feature = mapped
                     .get(exclude.clone())
@@ -144,16 +155,6 @@ fn render_dir(
                         continue 'next;
                     }
                 }
-            }
-
-            let mut cloned_cwd = cwd.clone();
-            for dir in preconditions.if_not_present {
-                // if any of these directories exist, bail
-                cloned_cwd.push(dir);
-                if cloned_cwd.as_path().exists() {
-                    continue 'next;
-                }
-                cloned_cwd.pop();
             }
         }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -17,6 +17,8 @@ pub struct When {
     pub(crate) none_of: Vec<String>,
     #[serde(default)]
     pub(crate) if_not_present: Vec<String>,
+    #[serde(default)]
+    pub(crate) any_of: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Default, Clone, Debug)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -21,6 +21,36 @@ pub struct When {
     pub(crate) any_of: Vec<String>,
 }
 
+impl When {
+    /// Returns true if the passed-in settings meet the conditions described by the When.
+    /// Does not consider `if_not_present` because the test for presence varies depending
+    /// on what the spec is for: files vs runscripts.
+    pub fn are_satisfied_by(&self, settings: &serde_json::Value) -> bool {
+        let false_sentinel = Value::Bool(false);
+
+        let has_a_prereq = if !self.all_of.is_empty() {
+            self.all_of.iter().all(|feature| {
+                let has_feature = settings.get(feature).unwrap_or(&false_sentinel);
+                has_feature.as_bool().unwrap_or(false)
+            })
+        } else if !self.any_of.is_empty() {
+            self.any_of.iter().any(|feature| {
+                let has_feature = settings.get(feature).unwrap_or(&false_sentinel);
+                has_feature.as_bool().unwrap_or(false)
+            })
+        } else {
+            true
+        };
+
+        let has_no_exclusions = !self.none_of.iter().any(|feature| {
+            let has_feature = settings.get(feature).unwrap_or(&false_sentinel);
+            has_feature.as_bool().unwrap_or(false)
+        });
+
+        has_a_prereq && has_no_exclusions
+    }
+}
+
 #[derive(Serialize, Deserialize, Default, Clone, Debug)]
 pub struct Settings {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/templates/boltzmann.d.ts
+++ b/templates/boltzmann.d.ts
@@ -5,10 +5,10 @@ import { IncomingMessage, OutgoingMessage } from 'http'
 import { URL } from 'url'
 import { Accepts } from 'accepts'
 import { Cookie } from 'cookie'
-{%- if postgres %}
+{% if postgres -%}
 import { Client } from 'pg'
 {% endif -%}
-{%- if redis %}
+{% if redis -%}
 import { IHandyRedis } from 'handy-redis'
 {% endif -%}
 
@@ -55,13 +55,13 @@ export declare class Context {
   public get query(): { [key: string]: string }
   public get body(): Promise<{ [key: string]: string }>
   public get accepts(): Accepts
-  {%- if postgres %}
+  {% if postgres -%}
   get postgresClient(): Promise<Client>
   {% endif -%}
-  {%- if redis %}
+  {% if redis -%}
   get redisClient(): IHandyRedis
   {% endif -%}
-  {%- if honeycomb %}
+  {% if honeycomb -%}
   get traceURL(): string
   {% endif -%}
 
@@ -74,26 +74,26 @@ export namespace middleware {
   export const applyXFO: Middleware
   export const handleCORS: Middleware
   export const session: Middleware
-  {%- if jwt %}
+  {% if jwt -%}
   export const authenticateJWT: Middleware
   {% endif -%}
-  {%- if templates %}
+  {% if templates -%}
   export const template: Middleware
   export const templateContext: Middleware
   {% endif -%}
-  {%- if oauth %}
+  {% if oauth -%}
   export const oauth: Middleware
   export const handleOAuthLogin: Middleware
   export const handleOAuthLogout: Middleware
   export const handleOAuthCallback: Middleware
   {% endif -%}
-  {%- if staticfiles %}
+  {% if staticfiles -%}
   export const staticfiles: Middleware
   {% endif -%}
-  {%- if esbuild %}
+  {% if esbuild -%}
   export const esbuild: Middleware
   {% endif -%}
-  {%- if csrf %}
+  {% if csrf -%}
   export const applyCSRF: Middleware
   {% endif %}
 

--- a/templates/boltzmann.d.ts
+++ b/templates/boltzmann.d.ts
@@ -7,7 +7,7 @@ import { Accepts } from 'accepts'
 import { Cookie } from 'cookie'
 {%- if postgres %}
 import { Client } from 'pg'
-{%- endif -%}
+{% endif -%}
 {%- if redis %}
 import { IHandyRedis } from 'handy-redis'
 {% endif -%}
@@ -57,10 +57,10 @@ export declare class Context {
   public get accepts(): Accepts
   {%- if postgres %}
   get postgresClient(): Promise<Client>
-  {%- endif -%}
+  {% endif -%}
   {%- if redis %}
   get redisClient(): IHandyRedis
-  {%- endif -%}
+  {% endif -%}
   {%- if honeycomb %}
   get traceURL(): string
   {% endif -%}
@@ -76,26 +76,26 @@ export namespace middleware {
   export const session: Middleware
   {%- if jwt %}
   export const authenticateJWT: Middleware
-  {%- endif -%}
+  {% endif -%}
   {%- if templates %}
   export const template: Middleware
   export const templateContext: Middleware
-  {%- endif -%}
+  {% endif -%}
   {%- if oauth %}
   export const oauth: Middleware
   export const handleOAuthLogin: Middleware
   export const handleOAuthLogout: Middleware
   export const handleOAuthCallback: Middleware
-  {%- endif -%}
+  {% endif -%}
   {%- if staticfiles %}
   export const staticfiles: Middleware
-  {%- endif -%}
+  {% endif -%}
   {%- if esbuild %}
   export const esbuild: Middleware
-  {%- endif -%}
+  {% endif -%}
   {%- if csrf %}
   export const applyCSRF: Middleware
-  {%- endif %}
+  {% endif %}
 
   export namespace validate {
     export const body: Middleware

--- a/templates/eslintrc.js
+++ b/templates/eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     sourceType: 'module',
   },
   extends: ['plugin:@typescript-eslint/recommended', 'prettier/@typescript-eslint', 'plugin:prettier/recommended'],
-  ignorePatterns: ["target/", "boltzmann.js", "boltzmann.d.ts"],
+  ignorePatterns: ['target/', 'boltzmann.js', 'boltzmann.d.ts'],
   rules: {
     '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: '(_|Context)', argsIgnorePattern: '^_' }],
     '@typescript-eslint/no-var-requires': [0],

--- a/templates/nodemon.json
+++ b/templates/nodemon.json
@@ -1,6 +1,6 @@
 {
   "restartable": "rs",
-  "ext": "js,mjs,ts,json,cjs",
+  "ext": "js,mjs,ts,json,cjs,jsx,tsx",
   "ignore": [".git", "node_modules/", "dist/", "coverage/"],
   "execMap": {
     "ts": "node -r ts-node/register -r dotenv/config",

--- a/templates/nodemon.json
+++ b/templates/nodemon.json
@@ -1,5 +1,6 @@
 {
   "restartable": "rs",
+  "ext": "js,mjs,ts,json,cjs",
   "ignore": [".git", "node_modules/", "dist/", "coverage/"],
   "execMap": {
     "ts": "node -r ts-node/register -r dotenv/config",

--- a/templates/test_esm.js
+++ b/templates/test_esm.js
@@ -1,4 +1,5 @@
-import { test } from 'tap'
+import tap from 'tap'
+const { test } = tap
 import { middleware } from '../boltzmann.js'
 
 const _ = middleware.test({


### PR DESCRIPTION
To fix a problem with confusing messaging for the `mime` dependency,
implemented an `any_of` clause for the When struct. This enables a dependency
if any of its possible prerequisites are present. Put it to work with the
`mime` dep, which is pulled in when any of esbuild or staticfiles is enabled.

This made the wants-a-dep repeated check complex enough that it warranted
moving to a function, so this is now in `dep_wanted()`.

And then got to the thing I really wanted to do, which was make the run script
management output more compact. We note changes, additions, and when we want to
manage something but are declining because the user overrode us.

One last change: First-run output now gives a total dependencies-added count,
if logging is at info level. It continues to give the full output if the log
level is chattier.

And a bugfix: suppressed some over-aggro whitespace stripping in the d.ts template.