### PR TITLE
make docs header not overlap

### DIFF
--- a/docs/themes/boltzie/sass/main.scss
+++ b/docs/themes/boltzie/sass/main.scss
@@ -286,7 +286,7 @@ main {
   min-width: 72rem;
   align-items: flex-start;
   margin: 0 auto;
-  padding-top: 6.12em;
+  padding-top: 7.5em;
 
   nav {
     padding-top: 0.75rem;


### PR DESCRIPTION
In Safari 14.0.2, Firefox 86.0, the top of the content block is under the header in the docs. This just tweaks the main padding so it doesn't do that.

### Before:
![Screen Shot 2021-02-03 at 10 36 29](https://user-images.githubusercontent.com/891202/106771044-9166b480-660c-11eb-8bf7-29f4a057180f.png)

### After:
![Screen Shot 2021-02-03 at 10 36 21](https://user-images.githubusercontent.com/891202/106771082-99265900-660c-11eb-9dd3-34d7905ddda5.png)

