### PR TITLE
fix: use forked bole to log Error objects with custom fields

### DIFF
--- a/src/dependencies.ron
+++ b/src/dependencies.ron
@@ -62,8 +62,8 @@
     preconditions: None
   ),
   DependencySpec(
-    name: "bole",
-    version: "^4.0.0",
+    name: "@entropic/bole",
+    version: "^4.0.1",
     kind: Normal,
     preconditions: None
   ),

--- a/templates/boltzmann.js
+++ b/templates/boltzmann.js
@@ -48,7 +48,7 @@ const crypto = require('crypto')
 const CsrfTokens = require('csrf')
 // {% endif %}
 const http = require('http')
-const bole = require('bole')
+const bole = require('@entropic/bole')
 const path = require('path')
 const os = require('os')
 // {% if redis %}

--- a/templates/eslintrc.js
+++ b/templates/eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
     ecmaVersion: 2020,
     sourceType: 'module',
   },
-  extends: ['plugin:@typescript-eslint/recommended', 'prettier/@typescript-eslint', 'plugin:prettier/recommended'],
+  extends: ['plugin:@typescript-eslint/recommended', 'plugin:prettier/recommended'],
   ignorePatterns: ['target/', 'boltzmann.js', 'boltzmann.d.ts'],
   rules: {
     '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: '(_|Context)', argsIgnorePattern: '^_' }],


### PR DESCRIPTION
We forked bole to make it pass through all enumerable fields on
Error objects, which has the salutary effect of making errors
from input validation show up in logs. 

While we were there, updated eslint-prettier. This removes
a dependency on a typescript plugin in eslintrc.