### PR TITLE
Fix middleware in tests

### DIFF
--- a/templates/boltzmann.js
+++ b/templates/boltzmann.js
@@ -2589,7 +2589,7 @@ function test ({
     // routes in checkpoints.
     await postgresClient.query(`begin`)
 
-    middleware.push(() => next => async context => {
+    middleware.unshift(() => next => async context => {
       context._postgresConnection = postgresClient
       const savepointname = `test_${process.pid}_${Date.now()}_${savepointId++}`
       const isTransactional = context.method !== 'GET' && context.method !== 'HEAD'
@@ -2612,7 +2612,7 @@ function test ({
     // {% endif %}
     // {% if redis %}
     await redisClient.flushdb()
-    middleware.push(() => next => async context => {
+    middleware.unshift(() => next => async context => {
       context._redisClient = redisClient
       return next(context)
     })


### PR DESCRIPTION
Middleware in tests are ordered in a way that does not allow access to postgres or redis from test middleware. The middlewares that set up postgres/redis are pushed to the end of the middleware array by the test() function, instead of unshifted to the start so that they run before provided middleware.
This code changes .push() to .unshift() to fix it! :^)