### PR TITLE
update ajv to v8; accept custom ajv in validators

### DIFF
--- a/docs/content/concepts/04-accepting-input.md
+++ b/docs/content/concepts/04-accepting-input.md
@@ -39,32 +39,33 @@ User input comes in three forms:
 
 ## Validating User Input
 
-Boltzmann provides three validator decorators that rely on [the ajv schema
-validator](https://github.com/epoberezkin/ajv) for you to enforce a schema for
-your route parameters, query params, and body. The functions are:
+Boltzmann provides three validator middleware that rely on [the ajv schema
+validator] for you to enforce a schema for your route parameters, query params,
+and body. The functions are:
 
-- `boltzmann.decorators.body`: validate the structure of an incoming body
-- `boltzmann.decorators.query`: validate parameters in the query string
-- `boltzmann.decorators.params`: validate route parameters
+- `boltzmann.middleware.validate.body`: validate the structure of an incoming body
+- `boltzmann.middleware.validate.query`: validate parameters in the query string
+- `boltzmann.middleware.validate.params`: validate route parameters
 
 Here's an example of a route parameter that must be a uuid:
 
 ```js
+const { middleware } = require('./boltzmann.js')
+
 identityDetail.route = 'GET /identities/identity/:id'
-identityDetail.decorators = [
-  boltzmann.decorators.params({
+identityDetail.middleware = [
+  [middleware.validate.params, {
     type: 'object',
     required: ['id'],
     properties: {
       id: { type: 'string', format: 'uuid' }
     }
-  })
+  }]
 ]
 async function identityDetail (/** @type {Context} */ context) { }
 ```
 
-The `boltzmann.decorators.params` function takes an ajv schema and generates a
-decorator that applies the schema to any route params supplied.
+[the ajv schema validator]: https://ajv.js.org/
 
 ## Writing Custom Body Parsers
 

--- a/docs/content/reference/02-handlers.md
+++ b/docs/content/reference/02-handlers.md
@@ -187,7 +187,6 @@ To escape a colon in the route, double it. E.g., `/web/::foo`.
 ```js
 // handlers.js
 module.exports = { handler }
-const { middleware } = require('./boltzmann')
 
 handler.route = 'GET /greet/:who'
 async function handler (context) {
@@ -198,6 +197,39 @@ async function handler (context) {
 ### `version`
 
 {{ changelog(version = "0.0.0") }}
+
+A string representing the version of the handler used for routing incoming
+requests that include an `accept-version` header.
+
+Automatically adds a [`vary: accept-version`] header to all responses from the
+handler to prevent cache poisoning attacks. If a single route has both
+versioned and un-versioned handlers, **you should add a [`vary:
+accept-version`] header** to the un-versioned handler. You can do so using the
+Boltzmann-provided [`vary`] middleware.
+
+**Example use**:
+
+```js
+// handlers.js
+module.exports = { handler }
+
+old.route = 'GET /'
+old.version = '0.0.0'
+async function old (context) {
+  return `hello world`
+}
+
+// will respond to requests with `accept-version: *`, `accept-version: 1.0.0`,
+// or `accept-version: ^1`.
+neue.route = 'GET /'
+neue.version = '1.0.0'
+async function neue (context) {
+  return `Hello, world!`
+}
+```
+
+[`vary: accept-version`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary
+[`vary`]: @/reference/03-middleware.md#vary
 
 ## Context
 

--- a/docs/content/reference/03-middleware.md
+++ b/docs/content/reference/03-middleware.md
@@ -336,6 +336,216 @@ module.exports = {
 }
 ```
 
+### `validate.body`
+
+{% changelog(version="0.0.0") %}
+- **Changed in 0.1.7:** Bugfix to support validator use as middleware.
+- **Changed in 0.2.0:** Added support for schemas defined via [`fluent-json-schema`].
+- **Changed in 0.5.0:** Added second options argument, accepting [`ajv`].
+{% end %}
+
+The `validate.body` middleware applies [JSON schema] validation to incoming
+request bodies. It intercepts the body that would be returned by
+[`context.body`] and validates it against the given schema, throwing a `400 Bad
+Request` error on validation failure. If the body passes validation it will be
+passed through.
+
+`Ajv` is configured with `{useDefaults: true}` by default. In development mode,
+`strictTypes` will be set to `true`. In non-development mode, it is set to
+`"log"`.
+
+**Arguments:**
+
+- `schema`: Positional. A [JSON schema] object defining valid input.
+- `options`: Positional.
+    - `ajv`: Named. Optionally provide a custom instance of [`ajv`].
+
+**Example Usage:**
+
+```js
+// handlers.js
+const { middleware } = require('boltzmann')
+
+example.middleware = [
+  [middleware.validate.body, {
+    type: 'object',
+    required: ['id'],
+    properties: {
+      id: { type: 'string', format: 'uuid' }
+    }
+  }]
+]
+example.route = 'POST /example'
+export async function example (context) {
+  // if body.id isn't a uuid, this throws a 400 Bad request error,
+  // otherwise it `id` will be a string containing a uuid:
+  const { id } = await context.body
+}
+
+const Ajv = require('ajv')
+customAjv.middleware = [
+  [middleware.validate.body, {
+    type: 'object',
+    required: ['id'],
+    properties: {
+      id: { type: 'string', format: 'uuid' }
+    }
+  }, {
+    // You can customize Ajv behavior by providing your own Ajv
+    // instance, like so:
+    ajv: new Ajv({
+      coerceTypes: true
+    })
+  }]
+]
+customAjv.route = 'POST /custom'
+export async function customAjv (context) {
+  // if body.id isn't a uuid, this throws a 400 Bad request error,
+  // otherwise it `id` will be a string containing a uuid:
+  const { id } = await context.body
+}
+```
+
+* * *
+
+### `validate.params`
+
+{% changelog(version="0.0.0") %}
+- **Changed in 0.1.7:** Bugfix to support validator use as middleware.
+- **Changed in 0.2.0:** Added support for schemas defined via [`fluent-json-schema`].
+- **Changed in 0.5.0:** Added second options argument, accepting `ajv`.
+{% end %}
+
+The `validate.params` middleware applies [JSON schema] validation to url
+parameters matched during request routing. Matched URL parameters are validated
+against the given schema, throwing a `400 Bad Request` error on validation
+failure, preventing execution of the handler. If the parameters pass validation
+the handler will be called.
+
+`Ajv` is configured with `{useDefaults: true, coerceTypes: "array"}` by
+default. In development mode, `strictTypes` will be set to `true`. In
+non-development mode, it is set to `"log"`.
+
+**Arguments:**
+
+- `schema`: Positional. A [JSON schema] object defining valid input.
+- `options`: Positional.
+    - `ajv`: Named. Optionally provide a custom instance of [`ajv`].
+
+**Example Usage:**
+
+```js
+// handlers.js
+const { middleware } = require('boltzmann')
+
+example.middleware = [
+  [middleware.validate.params, {
+    type: 'object',
+    required: ['id'],
+    properties: {
+      id: { type: 'string', format: 'uuid' }
+    }
+  }]
+]
+example.route = 'GET /example/:id'
+export async function example (context) {
+  const { id } = context.params
+}
+
+const Ajv = require('ajv')
+customAjv.middleware = [
+  [middleware.validate.params, {
+    type: 'object',
+    required: ['id'],
+    properties: {
+      id: { type: 'string', format: 'uuid' }
+    }
+  }, {
+    // You can customize Ajv behavior by providing your own Ajv
+    // instance, like so:
+    ajv: new Ajv({
+      coerceTypes: true
+    })
+  }]
+]
+customAjv.route = 'GET /:id'
+export async function customAjv (context) {
+  const { id } = context.params
+}
+```
+
+* * *
+
+### `validate.query`
+
+{% changelog(version="0.0.0") %}
+- **Changed in 0.1.7:** Bugfix to support validator use as middleware.
+- **Changed in 0.2.0:** Added support for schemas defined via [`fluent-json-schema`].
+- **Changed in 0.5.0:** Added second options argument, accepting `ajv`.
+{% end %}
+
+The `validate.query` middleware applies [JSON schema] validation to incoming
+HTTP query (or "search") parameters. Query parameters are validated against the
+given schema, throwing a `400 Bad Request` error on validation failure,
+preventing execution of the handler. If the query parameters pass validation the
+handler will be called.
+
+`Ajv` is configured with `{useDefaults: true, coerceTypes: "array"}` by
+default. In development mode, `strictTypes` will be set to `true`. In
+non-development mode, it is set to `"log"`.
+
+**Arguments:**
+
+- `schema`: Positional. A [JSON schema] object defining valid input.
+- `options`: Positional.
+    - `ajv`: Named. Optionally provide a custom instance of [`ajv`].
+
+**Example Usage:**
+
+```js
+// handlers.js
+const { middleware } = require('boltzmann')
+
+example.middleware = [
+  [middleware.validate.query, {
+    type: 'object',
+    required: ['id'],
+    properties: {
+      id: { type: 'string', format: 'uuid' }
+    }
+  }]
+]
+example.route = 'GET /example'
+export async function example (context) {
+  const { id } = context.query
+}
+
+const Ajv = require('ajv')
+customAjv.middleware = [
+  [middleware.validate.query, {
+    type: 'object',
+    required: ['id'],
+    properties: {
+      id: { type: 'string', format: 'uuid' }
+    }
+  }, {
+    // You can customize Ajv behavior by providing your own Ajv
+    // instance, like so:
+    ajv: new Ajv({
+      coerceTypes: true
+    })
+  }]
+]
+customAjv.route = 'GET /custom'
+export async function customAjv (context) {
+  const { id } = context.query
+}
+```
+
+[JSON schema]: https://json-schema.org/
+[`fluent-json-schema`]: https://www.npmjs.com/package/fluent-json-schema
+[`ajv`]: https://ajv.js.org/
+
 * * *
 
 ## Automatically attached middleware

--- a/docs/content/reference/03-middleware.md
+++ b/docs/content/reference/03-middleware.md
@@ -548,6 +548,48 @@ export async function customAjv (context) {
 
 * * *
 
+### `vary`
+
+{{ changelog(version="0.5.0") }}
+
+The `vary` middleware unconditionally updates responses to include a [`Vary`]
+header with the configured values. This is useful for handlers that change
+behavior based on `context.cookie`. It is automatically installed for handlers
+that use the [`.version` attribute].
+
+[`.version` attribute]: @/reference/02-handlers.md#version
+
+**Arguments:**
+
+- `on`: A string or list of strings, representing `Vary` values.
+
+**Example Usage:**
+
+```js
+// handlers.js
+const { middleware } = require('./boltzmann.js')
+cookies.middleware = [
+  [middleware.vary, 'cookie']
+]
+cookies.route = 'GET /'
+export function cookies(context) {
+  return context.cookie.get('wow') ? 'great' : 'not great'
+}
+
+// multiple values may be set at once.
+multi.middleware = [
+  [middleware.vary, ['cookie', 'accept-encoding']]
+]
+multi.route = 'GET /multi'
+export function multi(context) {
+  return context.cookie.get('wow') ? 'great' : 'not great'
+}
+```
+
+[`Vary`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary
+
+* * *
+
 ## Automatically attached middleware
 
 Automatically-attached middleware is middleware you can configure but do _not_ need to attach to

--- a/docs/content/reference/03-middleware.md
+++ b/docs/content/reference/03-middleware.md
@@ -347,11 +347,11 @@ module.exports = {
 The `validate.body` middleware applies [JSON schema] validation to incoming
 request bodies. It intercepts the body that would be returned by
 [`context.body`] and validates it against the given schema, throwing a `400 Bad
-Request` error on validation failure. If the body passes validation it will be
+Request` error on validation failure. If the body passes validation it is
 passed through.
 
 `Ajv` is configured with `{useDefaults: true, allErrors: true}` by default. In
-development mode, `strictTypes` will be set to `true`. In non-development mode,
+development mode, `strictTypes` is set to `true`. In non-development mode,
 it is set to `"log"`.
 
 **Arguments:**
@@ -380,7 +380,7 @@ example.middleware = [
 example.route = 'POST /example'
 export async function example (context) {
   // if body.id isn't a uuid, this throws a 400 Bad request error,
-  // otherwise it `id` will be a string containing a uuid:
+  // otherwise `id` is a string containing a uuid:
   const { id } = await context.body
 }
 
@@ -403,7 +403,7 @@ customAjv.middleware = [
 customAjv.route = 'POST /custom'
 export async function customAjv (context) {
   // if body.id isn't a uuid, this throws a 400 Bad request error,
-  // otherwise it `id` will be a string containing a uuid:
+  // otherwise `id` is a string containing a uuid:
   const { id } = await context.body
 }
 ```
@@ -422,10 +422,10 @@ The `validate.params` middleware applies [JSON schema] validation to url
 parameters matched during request routing. Matched URL parameters are validated
 against the given schema, throwing a `400 Bad Request` error on validation
 failure, preventing execution of the handler. If the parameters pass validation
-the handler will be called.
+the handler is called.
 
 `Ajv` is configured with `{allErrors: true, useDefaults: true, coerceTypes:
-"array"}` by default. In development mode, `strictTypes` will be set to `true`.
+"array"}` by default. In development mode, `strictTypes` is set to `true`.
 In non-development mode, it is set to `"log"`.
 
 **Arguments:**
@@ -492,10 +492,10 @@ The `validate.query` middleware applies [JSON schema] validation to incoming
 HTTP query (or "search") parameters. Query parameters are validated against the
 given schema, throwing a `400 Bad Request` error on validation failure,
 preventing execution of the handler. If the query parameters pass validation the
-handler will be called.
+handler is called.
 
 `Ajv` is configured with `{allErrors: true, useDefaults: true, coerceTypes:
-"array"}` by default. In development mode, `strictTypes` will be set to `true`.
+"array"}` by default. In development mode, `strictTypes` is set to `true`.
 In non-development mode, it is set to `"log"`.
 
 **Arguments:**

--- a/docs/content/reference/03-middleware.md
+++ b/docs/content/reference/03-middleware.md
@@ -350,11 +350,13 @@ request bodies. It intercepts the body that would be returned by
 Request` error on validation failure. If the body passes validation it will be
 passed through.
 
-`Ajv` is configured with `{useDefaults: true}` by default. In development mode,
-`strictTypes` will be set to `true`. In non-development mode, it is set to
-`"log"`.
+`Ajv` is configured with `{useDefaults: true, allErrors: true}` by default. In
+development mode, `strictTypes` will be set to `true`. In non-development mode,
+it is set to `"log"`.
 
 **Arguments:**
+
+`validate.body(schema[, { ajv }])`
 
 - `schema`: Positional. A [JSON schema] object defining valid input.
 - `options`: Positional.
@@ -422,11 +424,13 @@ against the given schema, throwing a `400 Bad Request` error on validation
 failure, preventing execution of the handler. If the parameters pass validation
 the handler will be called.
 
-`Ajv` is configured with `{useDefaults: true, coerceTypes: "array"}` by
-default. In development mode, `strictTypes` will be set to `true`. In
-non-development mode, it is set to `"log"`.
+`Ajv` is configured with `{allErrors: true, useDefaults: true, coerceTypes:
+"array"}` by default. In development mode, `strictTypes` will be set to `true`.
+In non-development mode, it is set to `"log"`.
 
 **Arguments:**
+
+`validate.params(schema[, { ajv }])`
 
 - `schema`: Positional. A [JSON schema] object defining valid input.
 - `options`: Positional.
@@ -490,11 +494,13 @@ given schema, throwing a `400 Bad Request` error on validation failure,
 preventing execution of the handler. If the query parameters pass validation the
 handler will be called.
 
-`Ajv` is configured with `{useDefaults: true, coerceTypes: "array"}` by
-default. In development mode, `strictTypes` will be set to `true`. In
-non-development mode, it is set to `"log"`.
+`Ajv` is configured with `{allErrors: true, useDefaults: true, coerceTypes:
+"array"}` by default. In development mode, `strictTypes` will be set to `true`.
+In non-development mode, it is set to `"log"`.
 
 **Arguments:**
+
+`validate.query(schema[, { ajv }])`
 
 - `schema`: Positional. A [JSON schema] object defining valid input.
 - `options`: Positional.

--- a/src/dependencies.ron
+++ b/src/dependencies.ron
@@ -81,7 +81,19 @@
   ),
   DependencySpec(
     name: "ajv",
-    version: "^6.12.2",
+    version: "^8.0.5",
+    kind: Normal,
+    preconditions: None
+  ),
+  DependencySpec(
+    name: "ajv-formats",
+    version: "^2.0.2",
+    kind: Normal,
+    preconditions: None
+  ),
+  DependencySpec(
+    name: "ajv-keywords",
+    version: "^5.0.0",
     kind: Normal,
     preconditions: None
   ),

--- a/src/dependencies.ron
+++ b/src/dependencies.ron
@@ -57,7 +57,7 @@
   ),
   DependencySpec(
     name: "find-my-way",
-    version: "^3.0.4",
+    version: "^4.1.0",
     kind: Normal,
     preconditions: None
   ),

--- a/templates/boltzmann.d.ts
+++ b/templates/boltzmann.d.ts
@@ -100,6 +100,7 @@ export namespace middleware {
   export const applyXFO: Middleware
   export const handleCORS: Middleware
   export const session: Middleware
+  export const vary: Middleware
   {% if jwt -%}
   export const authenticateJWT: Middleware
   {% endif -%}

--- a/templates/boltzmann.js
+++ b/templates/boltzmann.js
@@ -655,7 +655,7 @@ function route (handlers = {}) {
   }
 }
 
-function handler (context) {
+async function handler (context) {
   // {% if honeycomb %}
   let span = null
   if (process.env.HONEYCOMBIO_WRITE_KEY) {
@@ -671,7 +671,7 @@ function handler (context) {
 
   try {
     // {% endif %}
-    return context.handler(context, context.params, {}, null)
+    return await context.handler(context, context.params, {}, null)
     // {% if honeycomb %}
   } finally {
     if (process.env.HONEYCOMBIO_WRITE_KEY) {


### PR DESCRIPTION
This upgrades ajv from v6 to v8. ajv has had some breaking changes:

- ajv@7 changes how ajv instances are constructed and removes builtin
  formats and keywords. See [1].
- ajv@8 changes some details about error formatting. See [2].

We work around the changes in ajv@7 by adopting two new dependencies,
ajv-formats and ajv-keywords.

Additionally, we now set `useDefault: true` on all AJV instances so "default"
values are now used for absent properties (fixing an oversight on our part.)

Finally, we allow a custom AJV instance to be passed as part of a new "options"
argument to validator middleware. A rough example follows:

```
const Ajv = require('ajv')
route.middleware = [
  [validate.body, {..schema}, {ajv: new Ajv()}]
]
```

The three validator middleware now have entries in the docs.

[1] https://github.com/ajv-validator/ajv/releases/tag/v7.0.0
[2] https://github.com/ajv-validator/ajv/releases/tag/v8.0.0

------

upgrade find-my-way to 4.1.0; add vary middleware

`find-my-way` replaced its version negotiation feature with a more general "constraint" feature in v4. We now reinterpret handler.version as a constraint and forward incoming "accept-version" headers as constraints.

Further, this fixes a potential cache poisoning bug for routes provided by multiple handlers at different versions by automatically adding a `Vary: accept-version` to any versioned handler response. Malicious users could have used this bug to poison an intermediate caching proxy. The fix was accomplished by writing a "vary" middleware to automatically append headers, which felt useful enough to document and expose.
