### PR TITLE
Update Honeycomb environment variable names

### DIFF
--- a/docs/content/reference/03-middleware.md
+++ b/docs/content/reference/03-middleware.md
@@ -779,11 +779,10 @@ deep observability of the performance of your handlers.
 
 To configure this middleware, set the following environment variables:
 
--   `HONEYCOMBIO_WRITE_KEY`: the honeycomb API key to use; required to enable tracing
--   `HONEYCOMBIO_DATASET`: the name of the dataset to send trace data to; required to enable tracing
--   `HONEYCOMBIO_TEAM`: optional; set this to enable links to traces from error reporting
--   `HONEYCOMBIO_SAMPLE_RATE`: optional; passed to `honeycomb-beeline` to set the sampling rate for events
--   `HONEYCOMB_SAMPLE_RATE`: optional; consulted if `HONEYCOMBIO_SAMPLE_RATE` is not present
+-   `HONEYCOMB_WRITEKEY`: the honeycomb API key to use; required to enable tracing
+-   `HONEYCOMB_DATASET`: the name of the dataset to send trace data to; required to enable tracing
+-   `HONEYCOMB_TEAM`: optional; set this to enable links to traces from error reporting
+-   `HONEYCOMB_SAMPLE_RATE`: optional; passed to `honeycomb-beeline` to set the sampling rate for events
 
 The sampling rate defaults to 1 if neither sample rate env var is set. Tracing is
 disabled if a write key and dataset are not provided; the middleware is still

--- a/templates/boltzmann/core/middleware.ts
+++ b/templates/boltzmann/core/middleware.ts
@@ -86,7 +86,7 @@ async function handler (context: Context) {
   const handler = context.handler as Handler
   // {% if honeycomb %}
   let span = null
-  if (process.env.HONEYCOMBIO_WRITE_KEY) {
+  if (process.env.HONEYCOMB_WRITEKEY) {
     span = beeline.startSpan({
       name: `handler: ${handler.name}`,
       'handler.name': handler.name,
@@ -102,7 +102,7 @@ async function handler (context: Context) {
     return await handler(context)
     // {% if honeycomb %}
   } finally {
-    if (process.env.HONEYCOMBIO_WRITE_KEY && span !== null) {
+    if (process.env.HONEYCOMB_WRITEKEY && span !== null) {
       beeline.finishSpan(span)
     }
   }

--- a/templates/boltzmann/core/prelude.ts
+++ b/templates/boltzmann/core/prelude.ts
@@ -32,9 +32,9 @@ void `{% if honeycomb %}`;
 import beeline from 'honeycomb-beeline'
 
 beeline({
-  writeKey: process.env.HONEYCOMBIO_WRITE_KEY,
-  dataset: process.env.HONEYCOMBIO_DATASET,
-  sampleRate: Number(process.env.HONEYCOMBIO_SAMPLE_RATE) || Number(process.env.HONEYCOMB_SAMPLE_RATE) || 1,
+  writeKey: process.env.HONEYCOMB_WRITEKEY,
+  dataset: process.env.HONEYCOMB_DATASET,
+  sampleRate: Number(process.env.HONEYCOMB_SAMPLE_RATE) || 1,
   serviceName,
 })
 

--- a/templates/boltzmann/data/context.ts
+++ b/templates/boltzmann/data/context.ts
@@ -126,7 +126,7 @@ class Context {
   // {% if honeycomb %}
   /**{{- tsdoc(page="02-handlers.md", section="traceURL") -}}*/
   get traceURL () {
-    const url = new URL(`https://ui.honeycomb.io/${process.env.HONEYCOMBIO_TEAM}/datasets/${process.env.HONEYCOMBIO_DATASET}/trace`)
+    const url = new URL(`https://ui.honeycomb.io/${process.env.HONEYCOMB_TEAM}/datasets/${process.env.HONEYCOMB_DATASET}/trace`)
     url.searchParams.set('trace_id', this._honeycombTrace.payload['trace.trace_id'])
     url.searchParams.set('trace_start_ts', String(Math.floor(this._honeycombTrace.startTime/1000 - 1)))
     return String(url)

--- a/templates/boltzmann/middleware/error_template.html
+++ b/templates/boltzmann/middleware/error_template.html
@@ -108,9 +108,9 @@
               {% else %}
               <details>
                 <summary>Not available.</summary>
-                Make sure the <code>HONEYCOMBIO_DATASET</code>,
-                <code>HONEYCOMBIO_WRITE_KEY</code>, and
-                <code>HONEYCOMBIO_TEAM</code> environment variables are set,
+                Make sure the <code>HONEYCOMB_DATASET</code>,
+                <code>HONEYCOMB_WRITEKEY</code>, and
+                <code>HONEYCOMB_TEAM</code> environment variables are set,
                 then restart boltzmann.
               </details>
               {% endif %}

--- a/templates/boltzmann/middleware/honeycomb.ts
+++ b/templates/boltzmann/middleware/honeycomb.ts
@@ -12,7 +12,7 @@ void `{% endif %}`;
 function trace ({
   headerSources = ['x-honeycomb-trace', 'x-request-id'],
 } = {}) {
-  if (!process.env.HONEYCOMBIO_WRITE_KEY) {
+  if (!process.env.HONEYCOMB_WRITEKEY) {
     return (next: Handler) => (context: Context) => next(context)
   }
 
@@ -104,7 +104,7 @@ function trace ({
 }
 
 function honeycombMiddlewareSpans ({name}: {name?: string} = {}) {
-  if (!process.env.HONEYCOMBIO_WRITE_KEY) {
+  if (!process.env.HONEYCOMB_WRITEKEY) {
     return (next: Handler) => (context: Context) => next(context)
   }
 

--- a/templates/boltzmann/middleware/template.ts
+++ b/templates/boltzmann/middleware/template.ts
@@ -127,9 +127,9 @@ const devErrorTemplateSource = `
               {% else %}
               <details>
                 <summary>Not available.</summary>
-                Make sure the <code>HONEYCOMBIO_DATASET</code>,
-                <code>HONEYCOMBIO_WRITE_KEY</code>, and
-                <code>HONEYCOMBIO_TEAM</code> environment variables are set,
+                Make sure the <code>HONEYCOMB_DATASET</code>,
+                <code>HONEYCOMB_WRITEKEY</code>, and
+                <code>HONEYCOMB_TEAM</code> environment variables are set,
                 then restart boltzmann.
               </details>
               {% endif %}


### PR DESCRIPTION
The convention appears to be to use the `HONEYCOMB_` prefix (instead of
`HONEYCOMBIO_`):

* [`HONEYCOMB_WRITEKEY`](https://github.com/search?q=org%3Ahoneycombio+HONEYCOMB_WRITEKEY&type=code)
* [`HONEYCOMB_DATASET`](https://github.com/search?q=org%3Ahoneycombio+HONEYCOMB_DATASET&type=code)

We pass these (as well as the legacy names) through our global
variables.

Remove the support for `HONEYCOMBIO_SAMPLE_RATE`.

Ref eaze/infrastructure#923

I have attempted rescaffolding examples, but that resulted in a huge diff, probably because the scaffolding for examples was done with a `0.4.x` version of boltzmann.