### PR TITLE
cors does not throw

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         # eventually: add lts
-        node_version: ["12.x", "14.x"]
+        node_version: ["12.x", "14.x", "16.x"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The error-throwing behavior of Boltzmann's CORS middleware is unexpected
and unnecessary, it turns out! [1] [2]

[1]: https://github.com/expressjs/cors/blob/734e080a47c6ff5554b61cb43f7bd65e5909b30c/lib/index.js
[2]: https://github.com/fastify/fastify-cors/blob/a9445f9a30a08bfe51b967aa3aad58a9e9e9d773/index.js#L132

Fixes #104.
